### PR TITLE
Phase 0: Add SEO search-performance ingest + quotable block endpoints

### DIFF
--- a/scripts/api-hammer.ps1
+++ b/scripts/api-hammer.ps1
@@ -38,19 +38,19 @@ $Base = $Base.TrimEnd('/')
 
 function Get-ProjectHeaders {
     param(
-        [string]$Pid,
-        [string]$Pslug
+        [string]$ProjectIdValue,
+        [string]$ProjectSlugValue
     )
 
     $headers = @{}
 
-    if ($Pid -and $Pid.Trim().Length -gt 0) {
-        $headers["x-project-id"] = $Pid
+    if ($ProjectIdValue -and $ProjectIdValue.Trim().Length -gt 0) {
+        $headers["x-project-id"] = $ProjectIdValue
         return $headers
     }
 
-    if ($Pslug -and $Pslug.Trim().Length -gt 0) {
-        $headers["x-project-slug"] = $Pslug
+    if ($ProjectSlugValue -and $ProjectSlugValue.Trim().Length -gt 0) {
+        $headers["x-project-slug"] = $ProjectSlugValue
         return $headers
     }
 
@@ -58,8 +58,8 @@ function Get-ProjectHeaders {
     return $headers
 }
 
-$Headers = Get-ProjectHeaders -Pid $ProjectId -Pslug $ProjectSlug
-$OtherHeaders = Get-ProjectHeaders -Pid $OtherProjectId -Pslug $OtherProjectSlug
+$Headers = Get-ProjectHeaders -ProjectIdValue $ProjectId -ProjectSlugValue $ProjectSlug
+$OtherHeaders = Get-ProjectHeaders -ProjectIdValue $OtherProjectId -ProjectSlugValue $OtherProjectSlug
 
 Write-Host ("API Hammer - Testing " + $Base) -ForegroundColor Cyan
 if ($Headers.Count -gt 0) {

--- a/src/app/api/quotable-blocks/route.ts
+++ b/src/app/api/quotable-blocks/route.ts
@@ -1,0 +1,189 @@
+/**
+ * POST /api/quotable-blocks — Create a quotable block
+ *
+ * Phase 0-SEO manual endpoint for GEO citation asset creation.
+ * - Creates canonical QuotableBlock (not DraftArtifact)
+ * - Validates entityId belongs to same project
+ * - Emits QUOTABLE_BLOCK_CREATED event
+ *
+ * Multi-project hardened:
+ * - Resolves projectId from request
+ * - All writes scoped by projectId
+ * - Cross-project entityId returns 404
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { createdResponse, badRequest, notFound, serverError } from "@/lib/api-response";
+import { resolveProjectId } from "@/lib/project";
+import { ClaimType, EventType, EntityType, ActorType } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+// Explicit array of valid ClaimType values (type-safe)
+const VALID_CLAIM_TYPES: readonly ClaimType[] = [
+  ClaimType.statistic,
+  ClaimType.comparison,
+  ClaimType.definition,
+  ClaimType.howto_step,
+] as const;
+
+function isValidClaimType(value: unknown): value is ClaimType {
+  return typeof value === "string" && VALID_CLAIM_TYPES.includes(value as ClaimType);
+}
+
+// Strict ISO 8601 date validation (deterministic across environments)
+// Accepts ONLY:
+//   - Date-only: YYYY-MM-DD
+//   - UTC timestamp: YYYY-MM-DDTHH:mm:ssZ or YYYY-MM-DDTHH:mm:ss.sssZ
+// Rejects: locale formats, timezone offsets other than Z, missing Z on timestamps
+const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
+
+function isValidIsoDate(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+
+  const isDateOnly = ISO_DATE_ONLY_RE.test(value);
+  const isTimestamp = ISO_TIMESTAMP_RE.test(value);
+
+  if (!isDateOnly && !isTimestamp) return false;
+
+  const parsed = new Date(value);
+  if (isNaN(parsed.getTime())) return false;
+
+  // Round-trip check for date-only to ensure deterministic parsing
+  if (isDateOnly) {
+    return parsed.toISOString().slice(0, 10) === value;
+  }
+
+  // Timestamp with Z: parsing succeeded and format matched
+  return true;
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { projectId, error } = await resolveProjectId(request);
+    if (error) {
+      return badRequest(error);
+    }
+
+    // Parse request body
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return badRequest("Invalid JSON body");
+    }
+
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return badRequest("Request body must be an object");
+    }
+
+    const b = body as Record<string, unknown>;
+
+    // Validate entityId (required)
+    if (typeof b.entityId !== "string") {
+      return badRequest("entityId is required and must be a string");
+    }
+    if (!UUID_RE.test(b.entityId)) {
+      return badRequest("entityId must be a valid UUID");
+    }
+    const entityId = b.entityId;
+
+    // Validate text (required, non-empty)
+    if (typeof b.text !== "string" || b.text.trim().length === 0) {
+      return badRequest("text is required and must be a non-empty string");
+    }
+    const text = b.text.trim();
+
+    // Validate claimType (required, must match enum)
+    if (!isValidClaimType(b.claimType)) {
+      return badRequest(
+        `claimType must be one of: ${VALID_CLAIM_TYPES.join(", ")}`
+      );
+    }
+    const claimType = b.claimType;
+
+    // Validate sourceCitation (optional, must be string if provided)
+    let sourceCitation: string | null = null;
+    if (b.sourceCitation !== undefined && b.sourceCitation !== null) {
+      if (typeof b.sourceCitation !== "string") {
+        return badRequest("sourceCitation must be a string");
+      }
+      sourceCitation = b.sourceCitation.trim() || null;
+    }
+
+    // Validate topicTag (optional, must be string if provided)
+    let topicTag: string | null = null;
+    if (b.topicTag !== undefined && b.topicTag !== null) {
+      if (typeof b.topicTag !== "string") {
+        return badRequest("topicTag must be a string");
+      }
+      topicTag = b.topicTag.trim() || null;
+    }
+
+    // Validate verifiedUntil (optional, must be valid ISO date if provided)
+    let verifiedUntil: Date | null = null;
+    if (b.verifiedUntil !== undefined && b.verifiedUntil !== null) {
+      if (!isValidIsoDate(b.verifiedUntil)) {
+        return badRequest("verifiedUntil must be a valid ISO date string");
+      }
+      verifiedUntil = new Date(b.verifiedUntil);
+    }
+
+    // Verify entity exists AND belongs to this project
+    const entity = await prisma.entity.findUnique({
+      where: { id: entityId },
+      select: { id: true, projectId: true },
+    });
+
+    if (!entity) {
+      return notFound("Entity not found");
+    }
+
+    if (entity.projectId !== projectId) {
+      // Cross-project access: return 404 to avoid leaking existence
+      return notFound("Entity not found");
+    }
+
+    // Transactional create + event log (atomic)
+    const quotableBlock = await prisma.$transaction(async (tx) => {
+      const qb = await tx.quotableBlock.create({
+        data: {
+          projectId,
+          entityId,
+          text,
+          claimType,
+          sourceCitation,
+          topicTag,
+          verifiedUntil,
+        },
+      });
+
+      const details: Prisma.InputJsonObject = {
+        entityId,
+        claimType,
+        textLength: text.length,
+      };
+
+      await tx.eventLog.create({
+        data: {
+          eventType: EventType.QUOTABLE_BLOCK_CREATED,
+          entityType: EntityType.quotableBlock,
+          entityId: qb.id,
+          actor: ActorType.human,
+          projectId,
+          details,
+        },
+      });
+
+      return qb;
+    });
+
+    return createdResponse({ ok: true, id: quotableBlock.id });
+  } catch (error) {
+    console.error("POST /api/quotable-blocks error:", error);
+    return serverError();
+  }
+}

--- a/src/app/api/seo/search-performance/ingest/route.ts
+++ b/src/app/api/seo/search-performance/ingest/route.ts
@@ -1,0 +1,345 @@
+/**
+ * POST /api/seo/search-performance/ingest — Bulk ingest search performance data
+ *
+ * Phase 0-SEO manual endpoint for GSC opportunity query ingestion.
+ * - Accepts bulk rows (manual upload/paste)
+ * - Upserts by composite unique: (projectId, query, pageUrl, dateStart, dateEnd)
+ * - Validates entityId belongs to same project if provided
+ * - Single summary EventLog entry per batch
+ *
+ * Multi-project hardened:
+ * - Resolves projectId from request
+ * - All writes scoped by projectId
+ * - Cross-project entityId returns 404
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { successResponse, badRequest, notFound, serverError } from "@/lib/api-response";
+import { resolveProjectId } from "@/lib/project";
+import { EventType, EntityType, ActorType } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+interface SearchPerformanceRow {
+  query: string;
+  pageUrl: string;
+  impressions: number;
+  clicks: number;
+  ctr: number;
+  avgPosition: number;
+  dateStart: string;
+  dateEnd: string;
+  entityId?: string | null;
+}
+
+function isValidUrl(url: unknown): url is string {
+  if (typeof url !== "string" || url.trim().length === 0) return false;
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Strict ISO 8601 date validation (deterministic across environments)
+// Accepts ONLY:
+//   - Date-only: YYYY-MM-DD
+//   - UTC timestamp: YYYY-MM-DDTHH:mm:ssZ or YYYY-MM-DDTHH:mm:ss.sssZ
+// Rejects: locale formats, timezone offsets other than Z, missing Z on timestamps
+const ISO_DATE_ONLY_RE = /^\d{4}-\d{2}-\d{2}$/;
+const ISO_TIMESTAMP_RE = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,3})?Z$/;
+
+function isValidIsoDate(value: unknown): value is string {
+  if (typeof value !== "string") return false;
+
+  const isDateOnly = ISO_DATE_ONLY_RE.test(value);
+  const isTimestamp = ISO_TIMESTAMP_RE.test(value);
+
+  if (!isDateOnly && !isTimestamp) return false;
+
+  const parsed = new Date(value);
+  if (isNaN(parsed.getTime())) return false;
+
+  // Round-trip check for date-only to ensure deterministic parsing
+  if (isDateOnly) {
+    return parsed.toISOString().slice(0, 10) === value;
+  }
+
+  // Timestamp with Z: parsing succeeded and format matched
+  return true;
+}
+
+function validateRow(
+  row: unknown,
+  index: number
+): { valid: true; data: SearchPerformanceRow } | { valid: false; error: string } {
+  if (typeof row !== "object" || row === null) {
+    return { valid: false, error: `Row ${index}: must be an object` };
+  }
+
+  const r = row as Record<string, unknown>;
+
+  // query: non-empty string
+  if (typeof r.query !== "string" || r.query.trim().length === 0) {
+    return { valid: false, error: `Row ${index}: query must be a non-empty string` };
+  }
+
+  // pageUrl: valid URL
+  if (!isValidUrl(r.pageUrl)) {
+    return { valid: false, error: `Row ${index}: pageUrl must be a valid URL` };
+  }
+
+  // impressions: non-negative integer
+  if (
+    typeof r.impressions !== "number" ||
+    !Number.isFinite(r.impressions) ||
+    !Number.isInteger(r.impressions) ||
+    r.impressions < 0
+  ) {
+    return { valid: false, error: `Row ${index}: impressions must be a non-negative integer` };
+  }
+
+  // clicks: non-negative integer
+  if (
+    typeof r.clicks !== "number" ||
+    !Number.isFinite(r.clicks) ||
+    !Number.isInteger(r.clicks) ||
+    r.clicks < 0
+  ) {
+    return { valid: false, error: `Row ${index}: clicks must be a non-negative integer` };
+  }
+
+  // clicks <= impressions
+  if (r.clicks > r.impressions) {
+    return { valid: false, error: `Row ${index}: clicks cannot exceed impressions` };
+  }
+
+  // ctr: number between 0 and 1
+  if (
+    typeof r.ctr !== "number" ||
+    !Number.isFinite(r.ctr) ||
+    r.ctr < 0 ||
+    r.ctr > 1
+  ) {
+    return { valid: false, error: `Row ${index}: ctr must be a number between 0 and 1` };
+  }
+
+  // avgPosition: positive number
+  if (
+    typeof r.avgPosition !== "number" ||
+    !Number.isFinite(r.avgPosition) ||
+    r.avgPosition <= 0
+  ) {
+    return { valid: false, error: `Row ${index}: avgPosition must be a positive number` };
+  }
+
+  // dateStart: valid ISO date
+  if (!isValidIsoDate(r.dateStart)) {
+    return { valid: false, error: `Row ${index}: dateStart must be a valid ISO date string` };
+  }
+
+  // dateEnd: valid ISO date
+  if (!isValidIsoDate(r.dateEnd)) {
+    return { valid: false, error: `Row ${index}: dateEnd must be a valid ISO date string` };
+  }
+
+  // dateStart <= dateEnd
+  const startDate = new Date(r.dateStart);
+  const endDate = new Date(r.dateEnd);
+  if (startDate > endDate) {
+    return { valid: false, error: `Row ${index}: dateStart must be <= dateEnd` };
+  }
+
+  // entityId: optional, must be valid UUID if provided
+  let entityId: string | null = null;
+  if (r.entityId !== undefined && r.entityId !== null) {
+    if (typeof r.entityId !== "string" || !UUID_RE.test(r.entityId)) {
+      return { valid: false, error: `Row ${index}: entityId must be a valid UUID` };
+    }
+    entityId = r.entityId;
+  }
+
+  return {
+    valid: true,
+    data: {
+      query: r.query.trim(),
+      pageUrl: r.pageUrl as string,
+      impressions: r.impressions,
+      clicks: r.clicks,
+      ctr: r.ctr,
+      avgPosition: r.avgPosition,
+      dateStart: r.dateStart as string,
+      dateEnd: r.dateEnd as string,
+      entityId,
+    },
+  };
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    const { projectId, error } = await resolveProjectId(request);
+    if (error) {
+      return badRequest(error);
+    }
+
+    // Parse request body
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return badRequest("Invalid JSON body");
+    }
+
+    // Body must be object with rows array
+    if (typeof body !== "object" || body === null) {
+      return badRequest("Request body must be an object");
+    }
+
+    const b = body as Record<string, unknown>;
+    const rows = b.rows;
+
+    if (!Array.isArray(rows)) {
+      return badRequest("rows must be an array");
+    }
+
+    if (rows.length === 0) {
+      return badRequest("rows array cannot be empty");
+    }
+
+    // Validate all rows first
+    const validatedRows: SearchPerformanceRow[] = [];
+    for (let i = 0; i < rows.length; i++) {
+      const result = validateRow(rows[i], i);
+      if (!result.valid) {
+        return badRequest(result.error);
+      }
+      validatedRows.push(result.data);
+    }
+
+    // Collect unique entityIds for batch verification
+    const entityIdsToVerify = new Set<string>();
+    for (const row of validatedRows) {
+      if (row.entityId) {
+        entityIdsToVerify.add(row.entityId);
+      }
+    }
+
+    // Verify all referenced entities exist and belong to this project
+    if (entityIdsToVerify.size > 0) {
+      const entities = await prisma.entity.findMany({
+        where: {
+          id: { in: Array.from(entityIdsToVerify) },
+        },
+        select: { id: true, projectId: true },
+      });
+
+      const entityMap = new Map(entities.map((e) => [e.id, e.projectId]));
+
+      for (const entityId of entityIdsToVerify) {
+        const entityProjectId = entityMap.get(entityId);
+        if (!entityProjectId) {
+          return notFound(`Entity not found: ${entityId}`);
+        }
+        if (entityProjectId !== projectId) {
+          // Cross-project access: return 404 to avoid leaking existence
+          return notFound(`Entity not found: ${entityId}`);
+        }
+      }
+    }
+
+    // Deterministic processing order: sort by (query, pageUrl, dateStart, dateEnd)
+    const sortedRows = [...validatedRows].sort((a, b) => {
+      const cmp1 = a.query.localeCompare(b.query);
+      if (cmp1 !== 0) return cmp1;
+      const cmp2 = a.pageUrl.localeCompare(b.pageUrl);
+      if (cmp2 !== 0) return cmp2;
+      const cmp3 = a.dateStart.localeCompare(b.dateStart);
+      if (cmp3 !== 0) return cmp3;
+      return a.dateEnd.localeCompare(b.dateEnd);
+    });
+
+    // Track date window for summary
+    let minDateStart: Date | null = null;
+    let maxDateEnd: Date | null = null;
+
+    // Transactional upsert + event log (atomic)
+    const rowCount = await prisma.$transaction(async (tx) => {
+      let count = 0;
+
+      for (const row of sortedRows) {
+        const dateStart = new Date(row.dateStart);
+        const dateEnd = new Date(row.dateEnd);
+
+        // Track date window
+        if (!minDateStart || dateStart < minDateStart) {
+          minDateStart = dateStart;
+        }
+        if (!maxDateEnd || dateEnd > maxDateEnd) {
+          maxDateEnd = dateEnd;
+        }
+
+        await tx.searchPerformance.upsert({
+          where: {
+            projectId_query_pageUrl_dateStart_dateEnd: {
+              projectId,
+              query: row.query,
+              pageUrl: row.pageUrl,
+              dateStart,
+              dateEnd,
+            },
+          },
+          create: {
+            projectId,
+            entityId: row.entityId ?? null,
+            pageUrl: row.pageUrl,
+            query: row.query,
+            impressions: row.impressions,
+            clicks: row.clicks,
+            ctr: row.ctr,
+            avgPosition: row.avgPosition,
+            dateStart,
+            dateEnd,
+          },
+          update: {
+            entityId: row.entityId ?? null,
+            impressions: row.impressions,
+            clicks: row.clicks,
+            ctr: row.ctr,
+            avgPosition: row.avgPosition,
+          },
+        });
+
+        count++;
+      }
+
+      // Emit summary EventLog entry
+      const details: Prisma.InputJsonObject = {
+        model: "searchPerformance",
+        rowCount: count,
+        dateWindowStart: minDateStart?.toISOString() ?? null,
+        dateWindowEnd: maxDateEnd?.toISOString() ?? null,
+      };
+
+      await tx.eventLog.create({
+        data: {
+          eventType: EventType.ENTITY_UPDATED,
+          entityType: EntityType.project,
+          entityId: projectId,
+          actor: ActorType.human,
+          projectId,
+          details,
+        },
+      });
+
+      return count;
+    });
+
+    return successResponse({ ok: true, rowCount });
+  } catch (error) {
+    console.error("POST /api/seo/search-performance/ingest error:", error);
+    return serverError();
+  }
+}


### PR DESCRIPTION
PR Description
Summary

Implements Phase 0 manual SEO instrumentation endpoints:

POST /api/seo/search-performance/ingest

POST /api/quotable-blocks

These endpoints are fully multi-project hardened, transactionally event-logged, and deterministic.

No schema changes. No migration changes. No unrelated refactors.

Endpoints
1) POST /api/seo/search-performance/ingest

Bulk manual ingest of GSC-style search performance rows.

Upserts by composite unique:
(projectId, query, pageUrl, dateStart, dateEnd)

Strict ISO date validation (date-only or UTC ...Z)

Deterministic processing order:
(query, pageUrl, dateStart, dateEnd)

All writes inside a single prisma.$transaction()

Emits one summary EventLog entry:

eventType: ENTITY_UPDATED

entityType: project

details.model = "searchPerformance"

Includes rowCount and date window

Cross-project entityId references return 404.

2) POST /api/quotable-blocks

Creates canonical QuotableBlock records (not DraftArtifacts).

Validates entityId exists and belongs to the current project

Strict ISO validation for verifiedUntil

Enum-safe ClaimType validation

All writes inside a single prisma.$transaction()

Emits:

eventType: QUOTABLE_BLOCK_CREATED

entityType: quotableBlock

entityId = created block ID

Cross-project entity access returns 404.

Invariants Verified
Multi-project isolation

App-layer scoping via resolveProjectId()

Cross-project entity checks return 404

DB-layer triggers block cross-project SEO references

Verified via db-hammer against remote Neon

Transaction atomicity

All state mutations + EventLog entries occur inside prisma.$transaction()

Determinism

Explicit deterministic sorting before ingest

Stable ordering in list endpoints already enforced

Strict ISO validation avoids locale parsing ambiguity

Event logging

Ingest emits single summary event

QuotableBlock emits creation event

Events verified via /api/events

Validation Performed
Local

npm run lint — PASS

npm run build — PASS

DB-layer validation (remote Neon)
npx tsx scripts/db-hammer.ts --all --cleanup --remote-ok --i-understand

Result:

Cross-project relationship probe blocked

Cross-project QuotableBlock probe blocked

Cross-project SearchPerformance probe blocked

All invariant checks passed

Cleanup complete

API-layer validation
pwsh scripts/api-hammer.ps1 -ProjectSlug psymetric -OtherProjectSlug psymetric-b

Result:

Smoke tests PASS

Validation tests PASS

Pagination tests PASS

Cross-project entity fetch → 404 PASS

Events endpoint scoped correctly PASS

Scope

This PR does not:

Modify schema

Add migrations

Introduce automation

Change existing endpoints

Modify build behavior

Introduce DB access at build time

Phase 0 manual ingestion only.