### PR TITLE
Fix capture endpoint cross-project existence leak

### DIFF
--- a/src/app/api/source-items/capture/route.ts
+++ b/src/app/api/source-items/capture/route.ts
@@ -71,9 +71,8 @@ export async function POST(request: NextRequest) {
     if (existing) {
       // If the URL exists but belongs to another project, do not mutate across projects.
       if (existing.projectId !== projectId) {
-        return conflict(
-          "A SourceItem with this URL already exists in a different project"
-        );
+        // Preserve global uniqueness invariant without leaking cross-project existence
+        return conflict("URL already exists");
       }
 
       // --- Recapture: URL already exists --- (transactional)


### PR DESCRIPTION
Fixes invariant violation in POST /api/source-items/capture.

When a URL exists in another project, the endpoint previously returned a 409 with a message disclosing cross-project existence. This violated the non-disclosure isolation rule used across the rest of the API surface.

Change:
- Preserve global URL uniqueness constraint (still 409)
- Replace message with generic "URL already exists"

No schema changes.
No migration changes.
No lifecycle behavior changes.

Isolation invariant restored without altering status semantics.