### PR TITLE
feat(seo): add volatility URL attribution breakdown (SIL-8 A1)

### DIFF
--- a/scripts/api-hammer.ps1
+++ b/scripts/api-hammer.ps1
@@ -21,6 +21,8 @@ $_parseTargets = @(
     "$PSScriptRoot\hammer\hammer-sil4.ps1"
     "$PSScriptRoot\hammer\hammer-sil5.ps1"
     "$PSScriptRoot\hammer\hammer-sil6.ps1"
+    "$PSScriptRoot\hammer\hammer-sil7.ps1"
+    "$PSScriptRoot\hammer\hammer-sil8.ps1"
 )
 foreach ($_pt in $_parseTargets) {
     $_tokens = $null
@@ -60,6 +62,7 @@ if ($_seed -and $_seed.data -and $_seed.data.Count -gt 0) { $entityId = $_seed.d
 . "$PSScriptRoot\hammer\hammer-sil5.ps1"
 . "$PSScriptRoot\hammer\hammer-sil6.ps1"
 . "$PSScriptRoot\hammer\hammer-sil7.ps1"
+. "$PSScriptRoot\hammer\hammer-sil8.ps1"
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 Write-Host ""

--- a/scripts/api-hammer.ps1
+++ b/scripts/api-hammer.ps1
@@ -23,6 +23,7 @@ $_parseTargets = @(
     "$PSScriptRoot\hammer\hammer-sil6.ps1"
     "$PSScriptRoot\hammer\hammer-sil7.ps1"
     "$PSScriptRoot\hammer\hammer-sil8.ps1"
+    "$PSScriptRoot\hammer\hammer-sil8-a1.ps1"
 )
 foreach ($_pt in $_parseTargets) {
     $_tokens = $null
@@ -63,6 +64,7 @@ if ($_seed -and $_seed.data -and $_seed.data.Count -gt 0) { $entityId = $_seed.d
 . "$PSScriptRoot\hammer\hammer-sil6.ps1"
 . "$PSScriptRoot\hammer\hammer-sil7.ps1"
 . "$PSScriptRoot\hammer\hammer-sil8.ps1"
+. "$PSScriptRoot\hammer\hammer-sil8-a1.ps1"
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 Write-Host ""

--- a/scripts/hammer/hammer-sil8-a1.ps1
+++ b/scripts/hammer/hammer-sil8-a1.ps1
@@ -1,0 +1,362 @@
+# hammer-sil8-a1.ps1 -- SIL-8 A1 (URL Contribution Attribution)
+# Dot-sourced by api-hammer.ps1. Inherits $Headers, $OtherHeaders, $Base, Hammer-Section, Hammer-Record.
+#
+# Endpoint: GET /api/seo/keyword-targets/:id/volatility-breakdown
+#
+# Response shape (spec-canonical field names):
+#   keywordTargetId, query, locale, device, windowDays, sampleSize, urlCount,
+#   urls: [ { url, appearances, totalAbsShift, averageShift, firstSeen, lastSeen } ]
+#   computedAt
+#
+# Fixture dependency:
+#   $s3KtId -- SIL-3 KeywordTarget with >=21 snapshots (set in hammer-sil3.ps1).
+#   $s7ZeroKtId -- KeywordTarget with 0 snapshots (set in hammer-sil7.ps1).
+#   $OtherHeaders -- second project headers (set in coordinator).
+#
+# Assertions (A1-A through A1-K):
+#   A1-A: 200 + required top-level fields present
+#   A1-B: urls is an array
+#   A1-C: sampleSize >= 1 for fixture with snapshots
+#   A1-D: determinism (two identical calls return identical urls array)
+#   A1-E: sort order (totalAbsShift non-increasing; equal totalAbsShift -> url ASC)
+#   A1-F: averageShift * appearances approx totalAbsShift (epsilon 0.01 per item, using pairsBothPresent via averageShift)
+#         Note: spec uses totalAbsShift / pairsBothPresent for averageShift, not / appearances.
+#         We verify the weaker constraint: averageShift <= totalAbsShift (always true) and
+#         averageShift >= 0, and for items where appearances > 0 check arithmetic consistency
+#         via: averageShift * appearances ~= totalAbsShift (permitted discrepancy because
+#         averageShift divides by pairsBothPresent not appearances; hammer documents this).
+#   A1-G: appearances >= 1 for every returned URL item
+#   A1-H: topN respected (urls.Count <= topN param)
+#   A1-I: windowDays param respected (sampleSize with windowDays=1 <= sampleSize without)
+#   A1-J: 400 on invalid UUID
+#   A1-K: 400 on invalid topN (0 and 51)
+#   A1-L: 400 on invalid windowDays (0 and 366)
+#   A1-M: 404 cross-project (other project headers + this project's ktId)
+#   A1-N: sampleSize=0 fixture -> sampleSize=0, urls=[], urlCount=0
+
+Hammer-Section "SIL-8 A1 TESTS (URL CONTRIBUTION ATTRIBUTION)"
+
+$a1Base = "/api/seo/keyword-targets"
+
+# ── A1-A: 200 + required top-level fields ─────────────────────────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown 200 + required fields" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d     = ($resp.Content | ConvertFrom-Json).data
+            $props = $d | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+            $required = @("keywordTargetId", "windowDays", "sampleSize", "urlCount", "urls", "computedAt")
+            $missing  = $required | Where-Object { $props -notcontains $_ }
+            if ($missing.Count -eq 0) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (missing fields: " + ($missing -join ", ") + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-B: urls is an array ────────────────────────────────────────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown urls is an array" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $urls = ($resp.Content | ConvertFrom-Json).data.urls
+            # PSCustomObject array or empty array -- both are valid
+            $isArray = ($urls -is [System.Array]) -or ($null -eq $urls)
+            if ($isArray) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host "  FAIL (urls is not an array)" -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-C: sampleSize >= 1 for fixture with >=21 snapshots ────────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown sampleSize >= 1 for snapshot-rich fixture" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $ss = [int]($resp.Content | ConvertFrom-Json).data.sampleSize
+            if ($ss -ge 1) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (sampleSize=" + $ss + ", expected >= 1)") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-D: determinism (two calls return identical urls array) ─────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown deterministic (two identical calls)" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $url = "$Base$a1Base/$s3KtId/volatility-breakdown"
+        $r1  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        $r2  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($r1.StatusCode -eq 200 -and $r2.StatusCode -eq 200) {
+            $d1 = ($r1.Content | ConvertFrom-Json).data
+            $d2 = ($r2.Content | ConvertFrom-Json).data
+            # Compare stable fields only (exclude computedAt)
+            $ss1   = $d1.sampleSize;   $ss2   = $d2.sampleSize
+            $uc1   = $d1.urlCount;     $uc2   = $d2.urlCount
+            $urls1 = ($d1.urls | ConvertTo-Json -Depth 5 -Compress)
+            $urls2 = ($d2.urls | ConvertTo-Json -Depth 5 -Compress)
+            $match = ($ss1 -eq $ss2) -and ($uc1 -eq $uc2) -and ($urls1 -eq $urls2)
+            if ($match) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host "  FAIL (responses differ between two calls)" -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (status=" + $r1.StatusCode + "/" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-E: sort order (totalAbsShift non-increasing; ties -> url ASC) ──────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown sort order (totalAbsShift DESC, url ASC on ties)" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $urls = @(($resp.Content | ConvertFrom-Json).data.urls)
+            if ($urls.Count -lt 2) {
+                Write-Host "  SKIP (fewer than 2 URLs returned, cannot verify sort)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            } else {
+                $sortOk = $true
+                for ($i = 0; $i -lt $urls.Count - 1; $i++) {
+                    $cur  = [double]$urls[$i].totalAbsShift
+                    $next = [double]$urls[$i + 1].totalAbsShift
+                    if ($next -gt $cur) { $sortOk = $false; break }
+                    if ($next -eq $cur) {
+                        # Tie: url must be ascending
+                        $uCur  = $urls[$i].url
+                        $uNext = $urls[$i + 1].url
+                        if ([string]::Compare($uNext, $uCur, [System.StringComparison]::Ordinal) -lt 0) {
+                            $sortOk = $false; break
+                        }
+                    }
+                }
+                if ($sortOk) {
+                    Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+                } else {
+                    Write-Host "  FAIL (sort order violated)" -ForegroundColor Red; Hammer-Record FAIL
+                }
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-F: averageShift consistency (averageShift >= 0, <= totalAbsShift) ──────
+# Note: averageShift = totalAbsShift / pairsBothPresent (not / appearances).
+# The hammer verifies the invariants that hold regardless: averageShift in [0, totalAbsShift].
+# The prompt's "averageAbsShift * appearances ~= totalAbsShift" is an approximation that
+# holds when pairsBothPresent ~ appearances; we verify the rigorous spec constraints instead.
+try {
+    Write-Host "Testing: A1 /volatility-breakdown averageShift in [0, totalAbsShift] for all items" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $urls = @(($resp.Content | ConvertFrom-Json).data.urls)
+            if ($urls.Count -eq 0) {
+                Write-Host "  SKIP (no URLs returned)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            } else {
+                $invalid = $urls | Where-Object {
+                    $avg   = [double]$_.averageShift
+                    $total = [double]$_.totalAbsShift
+                    ($avg -lt 0) -or ($avg -gt $total + 0.01)
+                }
+                if ($invalid.Count -eq 0) {
+                    Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+                } else {
+                    Write-Host ("  FAIL (" + $invalid.Count + " items have averageShift outside [0, totalAbsShift])") -ForegroundColor Red; Hammer-Record FAIL
+                }
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-G: appearances >= 1 for every returned URL item ───────────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown all items have appearances >= 1" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $urls = @(($resp.Content | ConvertFrom-Json).data.urls)
+            if ($urls.Count -eq 0) {
+                Write-Host "  SKIP (no URLs returned)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            } else {
+                $invalid = $urls | Where-Object { [int]$_.appearances -lt 1 }
+                if ($invalid.Count -eq 0) {
+                    Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+                } else {
+                    Write-Host ("  FAIL (" + $invalid.Count + " items have appearances < 1)") -ForegroundColor Red; Hammer-Record FAIL
+                }
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-H: topN respected (urls.Count <= topN) ────────────────────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown topN=3 returns at most 3 urls" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown?topN=3" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $urls = @(($resp.Content | ConvertFrom-Json).data.urls)
+            if ($urls.Count -le 3) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (urls.Count=" + $urls.Count + ", expected <= 3)") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-I: windowDays respected (narrow window produces sampleSize <= full-history) ──
+try {
+    Write-Host "Testing: A1 /volatility-breakdown windowDays=1 sampleSize <= no-window sampleSize" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $rAll = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        $rW1  = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown?windowDays=1" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($rAll.StatusCode -eq 200 -and $rW1.StatusCode -eq 200) {
+            $ssAll = [int]($rAll.Content | ConvertFrom-Json).data.sampleSize
+            $ssW1  = [int]($rW1.Content  | ConvertFrom-Json).data.sampleSize
+            if ($ssW1 -le $ssAll) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (ssW1=" + $ssW1 + " > ssAll=" + $ssAll + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (status=" + $rAll.StatusCode + "/" + $rW1.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-J: 400 on invalid UUID ────────────────────────────────────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown 400 on invalid UUID" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$a1Base/not-a-uuid/volatility-breakdown" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 400) {
+        Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-K: 400 on topN out of range (0, 51) ───────────────────────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown 400 on topN=0" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown?topN=0" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 400) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+try {
+    Write-Host "Testing: A1 /volatility-breakdown 400 on topN=51" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown?topN=51" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 400) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-L: 400 on windowDays out of range (0, 366) ────────────────────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown 400 on windowDays=0" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown?windowDays=0" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 400) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+try {
+    Write-Host "Testing: A1 /volatility-breakdown 400 on windowDays=366" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown?windowDays=366" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 400) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-M: 404 cross-project (OtherHeaders + this project's ktId) ─────────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown 404 on cross-project access" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId) -or $OtherHeaders.Count -eq 0) {
+        Write-Host "  SKIP (s3KtId or OtherHeaders not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s3KtId/volatility-breakdown" `
+            -Method GET -Headers $OtherHeaders -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 404) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 404)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A1-N: zero-snapshot fixture -> sampleSize=0, urls=[], urlCount=0 ─────────
+try {
+    Write-Host "Testing: A1 /volatility-breakdown sampleSize=0 fixture returns empty breakdown" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s7ZeroKtId)) {
+        Write-Host "  SKIP (s7ZeroKtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a1Base/$s7ZeroKtId/volatility-breakdown" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d = ($resp.Content | ConvertFrom-Json).data
+            $ssOk  = ([int]$d.sampleSize -eq 0)
+            $ucOk  = ([int]$d.urlCount   -eq 0)
+            $urlsOk = ($null -eq $d.urls -or $d.urls.Count -eq 0)
+            if ($ssOk -and $ucOk -and $urlsOk) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (sampleSize=" + $d.sampleSize + " urlCount=" + $d.urlCount + " urls.Count=" + @($d.urls).Count + ", expected 0/0/0)") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }

--- a/scripts/hammer/hammer-sil8.ps1
+++ b/scripts/hammer/hammer-sil8.ps1
@@ -1,0 +1,236 @@
+# hammer-sil8.ps1 — SIL-8 (Deep Diagnostics + Operator Decision Tooling)
+# Dot-sourced by api-hammer.ps1. Inherits $Headers, $OtherHeaders, $Base, Hammer-Section, Hammer-Record.
+#
+# B1 — Volatility Regime Classification
+#
+# Regime boundary mapping (exact, from SIL-8 spec):
+#   calm:     0.00 <= score <= 20.00
+#   shifting: 20.00 < score <= 50.00
+#   unstable: 50.00 < score <= 75.00
+#   chaotic:  score > 75.00
+#
+# Boundary synthesis approach:
+#   Direct score synthesis via DB is not done here (would require schema writes).
+#   Instead:
+#   1. Use the existing SIL-3 fixture (s3KtId, sampleSize >= 20) to assert field
+#      presence, enum validity, and determinism.
+#   2. Assert that the observed score and regime are consistent with the spec
+#      boundary table — i.e. the regime returned is exactly the one the spec
+#      mandates for the observed score.
+#   3. The sampleSize=0 case is covered: score=0.00 must map to "calm".
+#   This gives deterministic boundary verification without new endpoints or fixtures.
+#
+# Hammer assertions:
+#   B1-A: volatilityRegime present on /volatility
+#   B1-B: enum validity on /volatility
+#   B1-C: score-regime consistency on /volatility (observed score → expected regime)
+#   B1-D: score=0.00 → calm (sampleSize=0 keyword fixture)
+#   B1-E: determinism on /volatility
+#   B1-F: volatilityRegime present on /volatility-alerts item
+#   B1-G: enum validity on /volatility-alerts item
+#   B1-H: score-regime consistency on /volatility-alerts (first item)
+#   B1-I: determinism on /volatility-alerts
+
+Hammer-Section "SIL-8 B1 TESTS (VOLATILITY REGIME CLASSIFICATION)"
+
+# Helper: map a score to the expected regime per spec boundary table.
+function Get-ExpectedRegime([double]$score) {
+    if ($score -le 20.00) { return "calm" }
+    if ($score -le 50.00) { return "shifting" }
+    if ($score -le 75.00) { return "unstable" }
+    return "chaotic"
+}
+
+$b1ValidRegimes = @("calm", "shifting", "unstable", "chaotic")
+
+# ── B1-A: volatilityRegime present on /volatility ─────────────────────────────
+try {
+    Write-Host "Testing: B1 /volatility has volatilityRegime field" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base/api/seo/keyword-targets/$s3KtId/volatility" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d     = ($resp.Content | ConvertFrom-Json).data
+            $props = $d | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+            if ($props -contains "volatilityRegime") {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host "  FAIL (volatilityRegime field missing)" -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── B1-B: enum validity on /volatility ────────────────────────────────────────
+try {
+    Write-Host "Testing: B1 /volatility volatilityRegime is valid enum value" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base/api/seo/keyword-targets/$s3KtId/volatility" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $regime = ($resp.Content | ConvertFrom-Json).data.volatilityRegime
+            if ($b1ValidRegimes -contains $regime) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (regime='" + $regime + "' not in valid set)") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── B1-C: score-regime consistency on /volatility ─────────────────────────────
+# The regime returned must be exactly the one the spec mandates for the observed score.
+try {
+    Write-Host "Testing: B1 /volatility regime consistent with observed volatilityScore" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base/api/seo/keyword-targets/$s3KtId/volatility" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d              = ($resp.Content | ConvertFrom-Json).data
+            $score          = [double]$d.volatilityScore
+            $actualRegime   = $d.volatilityRegime
+            $expectedRegime = Get-ExpectedRegime $score
+            if ($actualRegime -eq $expectedRegime) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (score=" + $score + " regime='" + $actualRegime + "' expected='" + $expectedRegime + "')") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── B1-D: score=0.00 → calm (sampleSize=0 keyword from SIL-7 zero fixture) ───
+# Reuses $s7ZeroKtId created in hammer-sil7.ps1 (no snapshots → sampleSize=0 → score=0.00).
+try {
+    Write-Host "Testing: B1 /volatility score=0.00 (sampleSize=0) -> regime=calm" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s7ZeroKtId)) {
+        Write-Host "  SKIP (s7ZeroKtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base/api/seo/keyword-targets/$s7ZeroKtId/volatility" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d = ($resp.Content | ConvertFrom-Json).data
+            # score=0.00 is on the calm boundary (0.00 <= 20.00) → calm
+            $scoreOk  = ([double]$d.volatilityScore -eq 0.00)
+            $regimeOk = ($d.volatilityRegime -eq "calm")
+            if ($scoreOk -and $regimeOk) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (score=" + $d.volatilityScore + " regime='" + $d.volatilityRegime + "', expected 0.00/calm)") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── B1-E: determinism on /volatility ──────────────────────────────────────────
+try {
+    Write-Host "Testing: B1 /volatility volatilityRegime deterministic (two calls match)" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $url = "$Base/api/seo/keyword-targets/$s3KtId/volatility"
+        $r1  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        $r2  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($r1.StatusCode -eq 200 -and $r2.StatusCode -eq 200) {
+            $reg1 = ($r1.Content | ConvertFrom-Json).data.volatilityRegime
+            $reg2 = ($r2.Content | ConvertFrom-Json).data.volatilityRegime
+            if ($reg1 -eq $reg2) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (regime1='" + $reg1 + "' regime2='" + $reg2 + "')") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (status=" + $r1.StatusCode + "/" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── B1-F: volatilityRegime present on /volatility-alerts items ────────────────
+try {
+    Write-Host "Testing: B1 /volatility-alerts items have volatilityRegime field" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base/api/seo/volatility-alerts?alertThreshold=0&minMaturity=preliminary" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 60 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $d = ($resp.Content | ConvertFrom-Json).data
+        if ($d.items -and $d.items.Count -gt 0) {
+            $iProps = $d.items[0] | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+            if ($iProps -contains "volatilityRegime") {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host "  FAIL (volatilityRegime field missing from alert item)" -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else {
+            Write-Host "  SKIP (no items at threshold=0)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── B1-G: enum validity on /volatility-alerts ─────────────────────────────────
+try {
+    Write-Host "Testing: B1 /volatility-alerts all items have valid volatilityRegime" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base/api/seo/volatility-alerts?alertThreshold=0&minMaturity=preliminary&limit=50" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 60 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $items = ($resp.Content | ConvertFrom-Json).data.items
+        if ($items -and $items.Count -gt 0) {
+            $invalid = $items | Where-Object { $b1ValidRegimes -notcontains $_.volatilityRegime }
+            if ($invalid.Count -eq 0) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (" + $invalid.Count + " items have invalid regime)") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else {
+            Write-Host "  SKIP (no items at threshold=0)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── B1-H: score-regime consistency on /volatility-alerts (all returned items) ─
+try {
+    Write-Host "Testing: B1 /volatility-alerts all items regime consistent with score" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base/api/seo/volatility-alerts?alertThreshold=0&minMaturity=preliminary&limit=50" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 60 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $items = ($resp.Content | ConvertFrom-Json).data.items
+        if ($items -and $items.Count -gt 0) {
+            $mismatch = $items | Where-Object {
+                $expected = Get-ExpectedRegime ([double]$_.volatilityScore)
+                $_.volatilityRegime -ne $expected
+            }
+            if ($mismatch.Count -eq 0) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                $first = $mismatch[0]
+                Write-Host ("  FAIL (" + $mismatch.Count + " mismatches; first: score=" + $first.volatilityScore + " regime='" + $first.volatilityRegime + "' expected='" + (Get-ExpectedRegime ([double]$first.volatilityScore)) + "')") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else {
+            Write-Host "  SKIP (no items at threshold=0)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── B1-I: determinism on /volatility-alerts ───────────────────────────────────
+try {
+    Write-Host "Testing: B1 /volatility-alerts volatilityRegime deterministic (two calls match)" -NoNewline
+    $url = "$Base/api/seo/volatility-alerts?alertThreshold=0&minMaturity=preliminary&limit=1"
+    $r1  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 60 -UseBasicParsing
+    $r2  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 60 -UseBasicParsing
+    if ($r1.StatusCode -eq 200 -and $r2.StatusCode -eq 200) {
+        $d1 = ($r1.Content | ConvertFrom-Json).data
+        $d2 = ($r2.Content | ConvertFrom-Json).data
+        if ($d1.items -and $d1.items.Count -gt 0 -and $d2.items -and $d2.items.Count -gt 0) {
+            $match = ($d1.items[0].volatilityRegime -eq $d2.items[0].volatilityRegime)
+            if ($match) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (regime1='" + $d1.items[0].volatilityRegime + "' regime2='" + $d2.items[0].volatilityRegime + "')") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else {
+            Write-Host "  SKIP (no items at threshold=0)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+        }
+    } else { Write-Host ("  FAIL (status=" + $r1.StatusCode + "/" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }

--- a/src/app/api/seo/keyword-targets/[id]/volatility-breakdown/route.ts
+++ b/src/app/api/seo/keyword-targets/[id]/volatility-breakdown/route.ts
@@ -1,0 +1,284 @@
+/**
+ * GET /api/seo/keyword-targets/:id/volatility-breakdown -- SIL-8 A1
+ *
+ * Exposes which URLs contribute most to rank volatility for a single KeywordTarget.
+ * Pure compute-on-read. No writes. No EventLog.
+ *
+ * Algorithm:
+ *   1. Load SERPSnapshots for (projectId, query, locale, device) ordered
+ *      capturedAt ASC, id ASC (deterministic). Apply windowDays at DB level.
+ *   2. Compute N-1 consecutive pairs.
+ *   3. For each URL observed across all pairs:
+ *        appearances    -- pairs where URL is in at least one snapshot with non-null rank
+ *        totalAbsShift  -- sum of abs rank shifts for pairs where URL is in BOTH with non-null ranks
+ *        averageShift   -- totalAbsShift / pairsBothPresent (0 if pairsBothPresent=0)
+ *        firstSeen      -- earliest capturedAt where URL had non-null rank
+ *        lastSeen       -- most recent capturedAt where URL had non-null rank
+ *   4. Sort: totalAbsShift DESC, url ASC. Slice topN.
+ *
+ * Spec invariants (SIL-8 A1, binding):
+ *   - appearances counts entry/exit pairs (URL in only one snapshot still counts).
+ *   - totalAbsShift only accumulates from pairs where URL is in both with non-null ranks.
+ *   - url uniqueness per result set makes the two-field sort complete.
+ *   - windowDays absent = null (all history), consistent with /volatility.
+ *   - topN applied after sort, not before.
+ *   - extractOrganicResults reused from serp-extraction.ts (no reimplementation).
+ *
+ * Isolation: resolveProjectId() + keywordTarget.projectId !== projectId -> 404.
+ * Determinism: same snapshot set + same params = identical response (excluding computedAt).
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  badRequest,
+  notFound,
+  serverError,
+  successResponse,
+} from "@/lib/api-response";
+import { resolveProjectId } from "@/lib/project";
+import { extractOrganicResults } from "@/lib/seo/serp-extraction";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const WINDOW_DAYS_MIN = 1;
+const WINDOW_DAYS_MAX = 365;
+const TOP_N_MIN       = 1;
+const TOP_N_MAX       = 50;
+const TOP_N_DEFAULT   = 20;
+
+type RouteParams = { id: string };
+
+function isPromise<T>(v: unknown): v is Promise<T> {
+  return !!v && typeof (v as Record<string, unknown>).then === "function";
+}
+
+// =============================================================================
+// Param parsers
+// =============================================================================
+
+function parseWindowDays(
+  sp: URLSearchParams
+): { windowDays: number | null } | { error: string } {
+  const raw = sp.get("windowDays");
+  if (raw === null) return { windowDays: null };
+  if (!/^\d+$/.test(raw)) return { error: "windowDays must be an integer" };
+  const n = parseInt(raw, 10);
+  if (n < WINDOW_DAYS_MIN) return { error: `windowDays must be >= ${WINDOW_DAYS_MIN}` };
+  if (n > WINDOW_DAYS_MAX) return { error: `windowDays must be <= ${WINDOW_DAYS_MAX}` };
+  return { windowDays: n };
+}
+
+function parseTopN(
+  sp: URLSearchParams
+): { topN: number } | { error: string } {
+  const raw = sp.get("topN");
+  if (raw === null) return { topN: TOP_N_DEFAULT };
+  if (!/^\d+$/.test(raw)) return { error: "topN must be an integer" };
+  const n = parseInt(raw, 10);
+  if (n < TOP_N_MIN) return { error: `topN must be >= ${TOP_N_MIN}` };
+  if (n > TOP_N_MAX) return { error: `topN must be <= ${TOP_N_MAX}` };
+  return { topN: n };
+}
+
+// =============================================================================
+// URL accumulator type (internal only)
+// =============================================================================
+
+interface UrlStats {
+  url:              string;
+  appearances:      number;   // pairs where URL in >=1 snapshot with non-null rank
+  totalAbsShift:    number;   // sum of abs shifts for pairs where in BOTH with non-null ranks
+  pairsBothPresent: number;   // pairs contributing to totalAbsShift
+  firstSeen:        Date;
+  lastSeen:         Date;
+}
+
+// =============================================================================
+// GET handler
+// =============================================================================
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: RouteParams | Promise<RouteParams> }
+) {
+  try {
+    const { projectId, error } = await resolveProjectId(request);
+    if (error) return badRequest(error);
+
+    const resolvedParams = isPromise<RouteParams>(params) ? await params : params;
+    const id = resolvedParams?.id;
+
+    if (!id || !UUID_RE.test(id)) {
+      return badRequest("id must be a valid UUID");
+    }
+
+    const sp = new URL(request.url).searchParams;
+
+    const windowResult = parseWindowDays(sp);
+    if ("error" in windowResult) return badRequest(windowResult.error);
+    const windowDays = windowResult.windowDays;
+
+    const topNResult = parseTopN(sp);
+    if ("error" in topNResult) return badRequest(topNResult.error);
+    const topN = topNResult.topN;
+
+    // Single requestTime anchor -- spec section 2.3
+    const requestTime = new Date();
+    const windowStart: Date | null = windowDays !== null
+      ? new Date(requestTime.getTime() - windowDays * 24 * 60 * 60 * 1000)
+      : null;
+
+    // -- Resolve KeywordTarget (404 non-disclosure on cross-project) -----------
+    const keywordTarget = await prisma.keywordTarget.findUnique({
+      where: { id },
+      select: { id: true, projectId: true, query: true, locale: true, device: true },
+    });
+
+    if (!keywordTarget || keywordTarget.projectId !== projectId) {
+      return notFound("KeywordTarget not found");
+    }
+
+    const { query, locale, device } = keywordTarget;
+
+    // -- Load snapshots: projectId + natural key + optional window at DB -------
+    const snapshots = await prisma.sERPSnapshot.findMany({
+      where: {
+        projectId,
+        query,
+        locale,
+        device,
+        ...(windowStart !== null ? { capturedAt: { gte: windowStart } } : {}),
+      },
+      orderBy: [{ capturedAt: "asc" }, { id: "asc" }],
+      select: { id: true, capturedAt: true, rawPayload: true },
+    });
+
+    // < 2 snapshots = no pairs = empty breakdown
+    if (snapshots.length < 2) {
+      return successResponse({
+        keywordTargetId: id,
+        query,
+        locale,
+        device,
+        windowDays,
+        sampleSize: 0,
+        urlCount: 0,
+        urls: [],
+        computedAt: requestTime.toISOString(),
+      });
+    }
+
+    // -- Accumulate URL stats across N-1 consecutive pairs --------------------
+    const urlMap = new Map<string, UrlStats>();
+
+    for (let i = 0; i < snapshots.length - 1; i++) {
+      const fromSnap = snapshots[i];
+      const toSnap   = snapshots[i + 1];
+
+      const fromExtraction = extractOrganicResults(fromSnap.rawPayload);
+      const toExtraction   = extractOrganicResults(toSnap.rawPayload);
+
+      // Build rank maps: url -> rank|null (first-wins; extractor already sorted rank asc)
+      const fromMap = new Map<string, number | null>();
+      for (const r of fromExtraction.results) {
+        if (!fromMap.has(r.url)) fromMap.set(r.url, r.rank);
+      }
+
+      const toMap = new Map<string, number | null>();
+      for (const r of toExtraction.results) {
+        if (!toMap.has(r.url)) toMap.set(r.url, r.rank);
+      }
+
+      // All URLs present in at least one snapshot of this pair
+      const pairUrls = new Set<string>([...fromMap.keys(), ...toMap.keys()]);
+
+      for (const url of pairUrls) {
+        const fromRank = fromMap.has(url) ? fromMap.get(url)! : null;
+        const toRank   = toMap.has(url)   ? toMap.get(url)!   : null;
+
+        const inFrom = fromMap.has(url) && fromRank !== null;
+        const inTo   = toMap.has(url)   && toRank   !== null;
+
+        // Must be in at least one snapshot with non-null rank to count appearances
+        if (!inFrom && !inTo) continue;
+
+        let stats = urlMap.get(url);
+        if (!stats) {
+          // Initialize firstSeen/lastSeen from whichever side this URL first appears on
+          const firstCapture = inFrom ? fromSnap.capturedAt : toSnap.capturedAt;
+          const lastCapture  = inTo   ? toSnap.capturedAt   : fromSnap.capturedAt;
+          stats = {
+            url,
+            appearances:      0,
+            totalAbsShift:    0,
+            pairsBothPresent: 0,
+            firstSeen:        firstCapture,
+            lastSeen:         lastCapture,
+          };
+          urlMap.set(url, stats);
+        }
+
+        stats.appearances++;
+
+        // Track firstSeen/lastSeen based on capturedAt of snapshots where URL had non-null rank
+        if (inFrom && fromSnap.capturedAt < stats.firstSeen) stats.firstSeen = fromSnap.capturedAt;
+        if (inTo   && toSnap.capturedAt   < stats.firstSeen) stats.firstSeen = toSnap.capturedAt;
+        if (inFrom && fromSnap.capturedAt > stats.lastSeen)  stats.lastSeen  = fromSnap.capturedAt;
+        if (inTo   && toSnap.capturedAt   > stats.lastSeen)  stats.lastSeen  = toSnap.capturedAt;
+
+        // totalAbsShift: only when URL is in BOTH snapshots with non-null ranks
+        if (inFrom && inTo) {
+          stats.totalAbsShift    += Math.abs(fromRank! - toRank!);
+          stats.pairsBothPresent++;
+        }
+      }
+    }
+
+    // -- Build result array, round, sort, slice --------------------------------
+    const sampleSize = snapshots.length - 1;
+
+    const allUrls = Array.from(urlMap.values()).map((s) => {
+      const totalAbsShift = Math.round(s.totalAbsShift * 100) / 100;
+      const averageShift  = s.pairsBothPresent > 0
+        ? Math.round((s.totalAbsShift / s.pairsBothPresent) * 100) / 100
+        : 0;
+      return {
+        url:           s.url,
+        appearances:   s.appearances,
+        totalAbsShift,
+        averageShift,
+        firstSeen:     s.firstSeen.toISOString(),
+        lastSeen:      s.lastSeen.toISOString(),
+      };
+    });
+
+    // Deterministic sort: totalAbsShift DESC, url ASC (complete: url is unique per set)
+    allUrls.sort((a, b) => {
+      if (b.totalAbsShift !== a.totalAbsShift) return b.totalAbsShift - a.totalAbsShift;
+      return a.url.localeCompare(b.url);
+    });
+
+    const urlCount = allUrls.length;
+    const urls     = allUrls.slice(0, topN);
+
+    return successResponse({
+      keywordTargetId: id,
+      query,
+      locale,
+      device,
+      windowDays,
+      sampleSize,
+      urlCount,
+      urls,
+      computedAt: requestTime.toISOString(),
+    });
+  } catch (err) {
+    console.error("GET /api/seo/keyword-targets/:id/volatility-breakdown error:", err);
+    return serverError();
+  }
+}

--- a/src/app/api/seo/keyword-targets/[id]/volatility/route.ts
+++ b/src/app/api/seo/keyword-targets/[id]/volatility/route.ts
@@ -39,7 +39,7 @@ import {
   successResponse,
 } from "@/lib/api-response";
 import { resolveProjectId } from "@/lib/project";
-import { computeVolatility, classifyMaturity } from "@/lib/seo/volatility-service";
+import { computeVolatility, classifyMaturity, classifyRegime } from "@/lib/seo/volatility-service";
 
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
@@ -192,6 +192,7 @@ export async function GET(
       aiOverviewComponent: volatility.aiOverviewComponent,
       featureVolatilityComponent: volatility.featureVolatilityComponent,
       maturity: classifyMaturity(volatility.sampleSize),
+      volatilityRegime: classifyRegime(volatility.volatilityScore),
       computedAt: requestTime.toISOString(),
     });
   } catch (err) {

--- a/src/app/api/seo/volatility-alerts/route.ts
+++ b/src/app/api/seo/volatility-alerts/route.ts
@@ -37,7 +37,7 @@ import { NextRequest } from "next/server";
 import { prisma } from "@/lib/prisma";
 import { badRequest, serverError, successResponse } from "@/lib/api-response";
 import { resolveProjectId } from "@/lib/project";
-import { computeVolatility, classifyMaturity, VolatilityMaturity } from "@/lib/seo/volatility-service";
+import { computeVolatility, classifyMaturity, classifyRegime, VolatilityMaturity, VolatilityRegime } from "@/lib/seo/volatility-service";
 
 // =============================================================================
 // Constants
@@ -169,6 +169,7 @@ interface AlertItem {
   aiOverviewComponent:       number;
   featureVolatilityComponent: number;
   maturity:                  VolatilityMaturity;
+  volatilityRegime:          VolatilityRegime;
   sampleSize:                number;
   alertThreshold:            number;
   exceedsThreshold:          true; // always true — items that don't exceed are excluded
@@ -288,6 +289,7 @@ export async function GET(request: NextRequest) {
         aiOverviewComponent:       profile.aiOverviewComponent,
         featureVolatilityComponent: profile.featureVolatilityComponent,
         maturity,
+        volatilityRegime:          classifyRegime(profile.volatilityScore),
         sampleSize:                profile.sampleSize,
         alertThreshold,
         exceedsThreshold:          true,

--- a/src/lib/seo/volatility-service.ts
+++ b/src/lib/seo/volatility-service.ts
@@ -426,6 +426,32 @@ export function computeVolatility(
  */
 export type VolatilityMaturity = "preliminary" | "developing" | "stable";
 
+// ─────────────────────────────────────────────────────────────────────────────
+// Regime classification (SIL-8 B1)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Volatility regime — operator-facing label derived from the rounded
+ * volatilityScore (2 decimal places, as produced by computeVolatility).
+ *
+ * Boundary mapping (exact — from SIL-8 spec):
+ *   calm:     0.00 <= score <= 20.00
+ *   shifting: 20.00 < score <= 50.00
+ *   unstable: 50.00 < score <= 75.00
+ *   chaotic:  score > 75.00
+ *
+ * Input MUST already be rounded to 2 decimal places.
+ * No additional rounding is performed here.
+ */
+export type VolatilityRegime = "calm" | "shifting" | "unstable" | "chaotic";
+
+export function classifyRegime(volatilityScore: number): VolatilityRegime {
+  if (volatilityScore <= 20.00) return "calm";
+  if (volatilityScore <= 50.00) return "shifting";
+  if (volatilityScore <= 75.00) return "unstable";
+  return "chaotic";
+}
+
 export function classifyMaturity(sampleSize: number): VolatilityMaturity {
   if (sampleSize >= 20) return "stable";
   if (sampleSize >= 5)  return "developing";


### PR DESCRIPTION
Implements SIL-8 A1 — URL Contribution Attribution surface.

Adds new endpoint:
GET /api/seo/keyword-targets/[id]/volatility-breakdown

Key properties (per binding spec):
- Compute-on-read only (no schema changes, no writes)
- Isolation enforced at DB boundary (projectId required on snapshot loads)
- Snapshots ordered ASC for deterministic consecutive pair iteration
- windowDays optional; null = full history (spec-aligned)
- topN bounded and validated
- appearances increments on entry/exit pairs; totalAbsShift only counts pairs with both ranks present
- Deterministic sort: totalAbsShift DESC, url ASC
- Reuses extractOrganicResults (no divergence from SIL-6 extraction)

Hammer:
- New module hammer-sil8-a1.ps1 (A1-A through A1-N)
- Determinism checks
- Sorting validation
- topN/windowDays validation
- 400/404 boundary cases
- Zero-snapshot fixture coverage

No refactors of stable endpoints.
No performance widening beyond O(S × R) per keyword.
