### PR TITLE
feat(seo): add feature transition matrix endpoint (SIL-8 A3)

### DIFF
--- a/scripts/api-hammer.ps1
+++ b/scripts/api-hammer.ps1
@@ -26,6 +26,7 @@ $_parseTargets = @(
     "$PSScriptRoot\hammer\hammer-sil8-a1.ps1"
     "$PSScriptRoot\hammer\hammer-sil8-a2.ps1"
     "$PSScriptRoot\hammer\hammer-sil8-b2.ps1"
+    "$PSScriptRoot\hammer\hammer-sil8-a3.ps1"
 )
 foreach ($_pt in $_parseTargets) {
     $_tokens = $null
@@ -69,6 +70,7 @@ if ($_seed -and $_seed.data -and $_seed.data.Count -gt 0) { $entityId = $_seed.d
 . "$PSScriptRoot\hammer\hammer-sil8-a1.ps1"
 . "$PSScriptRoot\hammer\hammer-sil8-a2.ps1"
 . "$PSScriptRoot\hammer\hammer-sil8-b2.ps1"
+. "$PSScriptRoot\hammer\hammer-sil8-a3.ps1"
 
 # ── Summary ────────────────────────────────────────────────────────────────────
 Write-Host ""

--- a/scripts/hammer/hammer-sil8-a3.ps1
+++ b/scripts/hammer/hammer-sil8-a3.ps1
@@ -1,0 +1,378 @@
+# hammer-sil8-a3.ps1 -- SIL-8 A3 (Feature Transition Matrix)
+# Dot-sourced by api-hammer.ps1. Inherits $Headers, $OtherHeaders, $Base, Hammer-Section, Hammer-Record.
+#
+# Endpoint: GET /api/seo/keyword-targets/:id/feature-transitions
+#
+# Response shape (spec-canonical):
+#   keywordTargetId, query, locale, device, windowDays,
+#   sampleSize, totalTransitions, distinctTransitionCount,
+#   transitions: [ { fromFeatureSet: string[], toFeatureSet: string[], count: number } ],
+#   computedAt
+#
+# Sum-check invariant: SUM(count) == sampleSize (every pair classified exactly once).
+#
+# Fixture dependency:
+#   $s3KtId      -- SIL-3 KeywordTarget with >= 21 snapshots
+#   $s7ZeroKtId  -- KeywordTarget with 0 snapshots (set in hammer-sil7.ps1)
+#   $OtherHeaders -- second project headers (set in coordinator)
+#
+# Tests (A3-A through A3-M):
+#   A3-A: 200 + required top-level fields present
+#   A3-B: transitions is an array
+#   A3-C: sampleSize >= 1 for snapshot-rich fixture
+#   A3-D: sum-check -- SUM(count) == sampleSize
+#   A3-E: totalTransitions == sampleSize (echoed field)
+#   A3-F: determinism (two calls identical excluding computedAt)
+#   A3-G: sort order -- count DESC, then fromKey ASC, then toKey ASC
+#   A3-H: per-transition required fields (fromFeatureSet array, toFeatureSet array, count)
+#   A3-I: fromFeatureSet and toFeatureSet are sorted ascending lexicographically
+#   A3-J: windowDays=1 sampleSize <= no-window sampleSize
+#   A3-K: invalid UUID -> 400
+#   A3-L: windowDays out of range (0, 366) -> 400
+#   A3-M: cross-project -> 404
+#   A3-N: zero-snapshot fixture -> sampleSize=0, transitions=[]
+
+Hammer-Section "SIL-8 A3 TESTS (FEATURE TRANSITION MATRIX)"
+
+$a3Base = "/api/seo/keyword-targets"
+
+# ── A3-A: 200 + required top-level fields ─────────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions 200 + required top-level fields" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d     = ($resp.Content | ConvertFrom-Json).data
+            $props = $d | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+            $required = @("keywordTargetId","windowDays","sampleSize","totalTransitions",
+                          "distinctTransitionCount","transitions","computedAt")
+            $missing = $required | Where-Object { $props -notcontains $_ }
+            if ($missing.Count -eq 0) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (missing: " + ($missing -join ", ") + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-B: transitions is an array ────────────────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions transitions field is an array" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $val = ($resp.Content | ConvertFrom-Json).data.transitions
+            $isArr = ($val -is [System.Array]) -or ($null -eq $val)
+            if ($isArr) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host "  FAIL (transitions is not an array)" -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-C: sampleSize >= 1 for snapshot-rich fixture ──────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions sampleSize >= 1 for snapshot-rich fixture" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $ss = [int]($resp.Content | ConvertFrom-Json).data.sampleSize
+            if ($ss -ge 1) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (sampleSize=" + $ss + ", expected >= 1 for s3KtId fixture)") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-D: sum-check SUM(count) == sampleSize ─────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions sum(count) == sampleSize" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d        = ($resp.Content | ConvertFrom-Json).data
+            $ss       = [int]$d.sampleSize
+            $items    = @($d.transitions)
+            $countSum = 0
+            foreach ($item in $items) { $countSum += [int]$item.count }
+            if ($countSum -eq $ss) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (sum(count)=" + $countSum + " != sampleSize=" + $ss + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-E: totalTransitions == sampleSize ─────────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions totalTransitions == sampleSize" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d  = ($resp.Content | ConvertFrom-Json).data
+            $ss = [int]$d.sampleSize
+            $tt = [int]$d.totalTransitions
+            if ($tt -eq $ss) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (totalTransitions=" + $tt + " != sampleSize=" + $ss + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-F: determinism ─────────────────────────────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions deterministic (two calls identical, excluding computedAt)" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $url = "$Base$a3Base/$s3KtId/feature-transitions"
+        $r1  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        $r2  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($r1.StatusCode -eq 200 -and $r2.StatusCode -eq 200) {
+            $d1 = ($r1.Content | ConvertFrom-Json).data
+            $d2 = ($r2.Content | ConvertFrom-Json).data
+            $ssMatch = ($d1.sampleSize -eq $d2.sampleSize)
+            $t1 = ($d1.transitions | ConvertTo-Json -Depth 8 -Compress)
+            $t2 = ($d2.transitions | ConvertTo-Json -Depth 8 -Compress)
+            $tMatch = ($t1 -eq $t2)
+            if ($ssMatch -and $tMatch) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host "  FAIL (transitions differ between two calls)" -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (status=" + $r1.StatusCode + "/" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-G: sort order (count DESC, fromKey ASC, toKey ASC) ────────────────────
+# fromKey = fromFeatureSet joined by comma; toKey = toFeatureSet joined by comma.
+try {
+    Write-Host "Testing: A3 /feature-transitions sort order (count DESC, fromKey ASC, toKey ASC)" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $items = @(($resp.Content | ConvertFrom-Json).data.transitions)
+            if ($items.Count -lt 2) {
+                Write-Host "  PASS (fewer than 2 transitions, sort trivially satisfied)" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                $sortOk = $true
+                for ($i = 0; $i -lt $items.Count - 1; $i++) {
+                    $cur  = $items[$i]
+                    $nxt  = $items[$i + 1]
+                    $cCur = [int]$cur.count
+                    $cNxt = [int]$nxt.count
+                    if ($cNxt -gt $cCur) { $sortOk = $false; break }
+                    if ($cNxt -eq $cCur) {
+                        # Derive fromKey / toKey by joining the feature-set arrays
+                        $fkCur = if ($null -eq $cur.fromFeatureSet)  { "" } else { ($cur.fromFeatureSet  -join ",") }
+                        $fkNxt = if ($null -eq $nxt.fromFeatureSet)  { "" } else { ($nxt.fromFeatureSet  -join ",") }
+                        $cmpFk = [string]::Compare($fkCur, $fkNxt, [System.StringComparison]::Ordinal)
+                        if ($cmpFk -gt 0) { $sortOk = $false; break }
+                        if ($cmpFk -eq 0) {
+                            $tkCur = if ($null -eq $cur.toFeatureSet) { "" } else { ($cur.toFeatureSet -join ",") }
+                            $tkNxt = if ($null -eq $nxt.toFeatureSet) { "" } else { ($nxt.toFeatureSet -join ",") }
+                            $cmpTk = [string]::Compare($tkCur, $tkNxt, [System.StringComparison]::Ordinal)
+                            if ($cmpTk -gt 0) { $sortOk = $false; break }
+                        }
+                    }
+                }
+                if ($sortOk) {
+                    Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+                } else {
+                    Write-Host "  FAIL (sort order violated)" -ForegroundColor Red; Hammer-Record FAIL
+                }
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-H: per-transition required fields ─────────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions per-transition required fields" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $items = @(($resp.Content | ConvertFrom-Json).data.transitions)
+            if ($items.Count -eq 0) {
+                Write-Host "  SKIP (no transitions, cannot check item shape)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            } else {
+                $item    = $items[0]
+                $iProps  = $item | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+                $required = @("fromFeatureSet","toFeatureSet","count")
+                $missing = $required | Where-Object { $iProps -notcontains $_ }
+                if ($missing.Count -eq 0) {
+                    Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+                } else {
+                    Write-Host ("  FAIL (missing: " + ($missing -join ", ") + ")") -ForegroundColor Red; Hammer-Record FAIL
+                }
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-I: fromFeatureSet and toFeatureSet are sorted ascending ────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions fromFeatureSet and toFeatureSet sorted ascending" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $items = @(($resp.Content | ConvertFrom-Json).data.transitions)
+            if ($items.Count -eq 0) {
+                Write-Host "  SKIP (no transitions)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            } else {
+                $sortOk = $true
+                foreach ($item in $items) {
+                    # Check fromFeatureSet sorted
+                    $ffs = @($item.fromFeatureSet)
+                    if ($ffs.Count -ge 2) {
+                        $sorted = ($ffs | Sort-Object)
+                        for ($j = 0; $j -lt $ffs.Count; $j++) {
+                            if ($ffs[$j] -ne $sorted[$j]) { $sortOk = $false; break }
+                        }
+                    }
+                    if (-not $sortOk) { break }
+                    # Check toFeatureSet sorted
+                    $tfs = @($item.toFeatureSet)
+                    if ($tfs.Count -ge 2) {
+                        $sorted = ($tfs | Sort-Object)
+                        for ($j = 0; $j -lt $tfs.Count; $j++) {
+                            if ($tfs[$j] -ne $sorted[$j]) { $sortOk = $false; break }
+                        }
+                    }
+                    if (-not $sortOk) { break }
+                }
+                if ($sortOk) {
+                    Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+                } else {
+                    Write-Host "  FAIL (feature set not sorted ascending)" -ForegroundColor Red; Hammer-Record FAIL
+                }
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-J: windowDays=1 sampleSize <= no-window sampleSize ────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions windowDays=1 sampleSize <= no-window sampleSize" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $rAll = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        $rW1  = Invoke-WebRequest -Uri ($Base + $a3Base + "/" + $s3KtId + "/feature-transitions?windowDays=1") `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($rAll.StatusCode -eq 200 -and $rW1.StatusCode -eq 200) {
+            $ssAll = [int]($rAll.Content | ConvertFrom-Json).data.sampleSize
+            $ssW1  = [int]($rW1.Content  | ConvertFrom-Json).data.sampleSize
+            if ($ssW1 -le $ssAll) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (windowDays=1 sampleSize=" + $ssW1 + " > full sampleSize=" + $ssAll + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (status=" + $rAll.StatusCode + "/" + $rW1.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-K: invalid UUID -> 400 ────────────────────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions 400 on invalid UUID" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$a3Base/not-a-uuid/feature-transitions" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 400) {
+        Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-L: windowDays out of range -> 400 ─────────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions 400 on windowDays=0" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri ($Base + $a3Base + "/" + $s3KtId + "/feature-transitions?windowDays=0") `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 400) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+try {
+    Write-Host "Testing: A3 /feature-transitions 400 on windowDays=366" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri ($Base + $a3Base + "/" + $s3KtId + "/feature-transitions?windowDays=366") `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 400) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-M: cross-project -> 404 ───────────────────────────────────────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions 404 on cross-project access" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId) -or $OtherHeaders.Count -eq 0) {
+        Write-Host "  SKIP (s3KtId or OtherHeaders not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s3KtId/feature-transitions" `
+            -Method GET -Headers $OtherHeaders -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 404) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 404)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── A3-N: zero-snapshot fixture -> sampleSize=0, transitions=[] ──────────────
+try {
+    Write-Host "Testing: A3 /feature-transitions zero-snapshot fixture -> sampleSize=0, transitions=[]" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s7ZeroKtId)) {
+        Write-Host "  SKIP (s7ZeroKtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$a3Base/$s7ZeroKtId/feature-transitions" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $d    = ($resp.Content | ConvertFrom-Json).data
+            $ssOk = ([int]$d.sampleSize -eq 0)
+            $trOk = ($null -eq $d.transitions -or @($d.transitions).Count -eq 0)
+            if ($ssOk -and $trOk) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (sampleSize=" + $d.sampleSize + " transitions.Count=" + @($d.transitions).Count + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }

--- a/src/app/api/seo/keyword-targets/[id]/feature-transitions/route.ts
+++ b/src/app/api/seo/keyword-targets/[id]/feature-transitions/route.ts
@@ -1,0 +1,225 @@
+/**
+ * GET /api/seo/keyword-targets/:id/feature-transitions -- SIL-8 A3
+ *
+ * For a single KeywordTarget, computes how SERP feature sets transition between
+ * consecutive snapshots. Pure compute-on-read. No writes. No EventLog.
+ *
+ * Algorithm:
+ *   1. Load SERPSnapshots for (projectId, query, locale, device) ordered
+ *      capturedAt ASC, id ASC. Apply windowDays filter at DB level.
+ *   2. Compute N-1 consecutive pairs.
+ *   3. For each pair extract feature sets using extractFeatureSortedArray
+ *      (canonical, shared, deterministic -- from serp-extraction.ts).
+ *   4. Build transitionKey = fromKey + "\u2192" + toKey where:
+ *        fromKey = fromFeaturesSorted.join(",")  (empty set => "")
+ *        toKey   = toFeaturesSorted.join(",")    (empty set => "")
+ *   5. Aggregate count per transitionKey.
+ *   6. Sort: count DESC, fromKey ASC, toKey ASC.
+ *
+ * Sum-check invariant (binding):
+ *   SUM(count across all transitions) === sampleSize (number of pairs).
+ *   Every pair is classified exactly once.
+ *
+ * Spec response fields (SIL-8-PLAN.md A3):
+ *   fromFeatureSet (sorted string[]), toFeatureSet (sorted string[]), count.
+ *   Top-level: keywordTargetId, query, windowDays, sampleSize,
+ *               totalTransitions, distinctTransitionCount, transitions.
+ *
+ * Isolation: resolveProjectId() + keywordTarget.projectId !== projectId -> 404.
+ * Determinism: identical snapshot set + params = identical transitions array.
+ */
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+import {
+  badRequest,
+  notFound,
+  serverError,
+  successResponse,
+} from "@/lib/api-response";
+import { resolveProjectId } from "@/lib/project";
+import { extractFeatureSortedArray } from "@/lib/seo/serp-extraction";
+
+// =============================================================================
+// Constants
+// =============================================================================
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const WINDOW_DAYS_MIN = 1;
+const WINDOW_DAYS_MAX = 365;
+
+// U+2192 RIGHT ARROW -- canonical separator per spec. Does not appear in DataForSEO type strings.
+const TRANSITION_SEP = "\u2192";
+
+type RouteParams = { id: string };
+
+function isPromise<T>(v: unknown): v is Promise<T> {
+  return !!v && typeof (v as Record<string, unknown>).then === "function";
+}
+
+// =============================================================================
+// Param parsers
+// =============================================================================
+
+function parseWindowDays(
+  sp: URLSearchParams
+): { windowDays: number | null } | { error: string } {
+  const raw = sp.get("windowDays");
+  if (raw === null) return { windowDays: null };
+  if (!/^\d+$/.test(raw)) return { error: "windowDays must be an integer" };
+  const n = parseInt(raw, 10);
+  if (n < WINDOW_DAYS_MIN) return { error: `windowDays must be >= ${WINDOW_DAYS_MIN}` };
+  if (n > WINDOW_DAYS_MAX) return { error: `windowDays must be <= ${WINDOW_DAYS_MAX}` };
+  return { windowDays: n };
+}
+
+// =============================================================================
+// GET handler
+// =============================================================================
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: RouteParams | Promise<RouteParams> }
+) {
+  try {
+    const { projectId, error } = await resolveProjectId(request);
+    if (error) return badRequest(error);
+
+    const resolvedParams = isPromise<RouteParams>(params) ? await params : params;
+    const id = resolvedParams?.id;
+
+    if (!id || !UUID_RE.test(id)) {
+      return badRequest("id must be a valid UUID");
+    }
+
+    const sp = new URL(request.url).searchParams;
+
+    const windowResult = parseWindowDays(sp);
+    if ("error" in windowResult) return badRequest(windowResult.error);
+    const windowDays = windowResult.windowDays;
+
+    // Single requestTime anchor -- spec section 2.3
+    const requestTime = new Date();
+    const windowStart: Date | null = windowDays !== null
+      ? new Date(requestTime.getTime() - windowDays * 24 * 60 * 60 * 1000)
+      : null;
+
+    // -- Resolve KeywordTarget (404 non-disclosure on cross-project) -----------
+    const keywordTarget = await prisma.keywordTarget.findUnique({
+      where: { id },
+      select: { id: true, projectId: true, query: true, locale: true, device: true },
+    });
+
+    if (!keywordTarget || keywordTarget.projectId !== projectId) {
+      return notFound("KeywordTarget not found");
+    }
+
+    const { query, locale, device } = keywordTarget;
+
+    // -- Load snapshots: projectId + natural key + optional window at DB -------
+    const snapshots = await prisma.sERPSnapshot.findMany({
+      where: {
+        projectId,
+        query,
+        locale,
+        device,
+        ...(windowStart !== null ? { capturedAt: { gte: windowStart } } : {}),
+      },
+      orderBy: [{ capturedAt: "asc" }, { id: "asc" }],
+      select: { id: true, capturedAt: true, rawPayload: true },
+    });
+
+    // < 2 snapshots = no pairs
+    if (snapshots.length < 2) {
+      return successResponse({
+        keywordTargetId:         id,
+        query,
+        locale,
+        device,
+        windowDays,
+        sampleSize:              0,
+        totalTransitions:        0,
+        distinctTransitionCount: 0,
+        transitions:             [],
+        computedAt:              requestTime.toISOString(),
+      });
+    }
+
+    const sampleSize = snapshots.length - 1;
+
+    // -- Accumulate transition counts -----------------------------------------
+    // key: transitionKey (fromKey + ARROW + toKey)
+    // value: { fromFeatureSet, toFeatureSet, count }
+    interface TransitionEntry {
+      fromFeatureSet: string[];
+      toFeatureSet:   string[];
+      fromKey:        string;
+      toKey:          string;
+      count:          number;
+    }
+
+    const transitionMap = new Map<string, TransitionEntry>();
+
+    for (let i = 0; i < snapshots.length - 1; i++) {
+      const fromSnap = snapshots[i];
+      const toSnap   = snapshots[i + 1];
+
+      const fromFeatureSet = extractFeatureSortedArray(fromSnap.rawPayload);
+      const toFeatureSet   = extractFeatureSortedArray(toSnap.rawPayload);
+
+      // Canonical key construction (spec-binding):
+      //   fromKey = sorted features joined by comma (empty => "")
+      //   toKey   = sorted features joined by comma (empty => "")
+      //   transitionKey = fromKey + U+2192 + toKey
+      const fromKey       = fromFeatureSet.join(",");
+      const toKey         = toFeatureSet.join(",");
+      const transitionKey = fromKey + TRANSITION_SEP + toKey;
+
+      const existing = transitionMap.get(transitionKey);
+      if (existing) {
+        existing.count++;
+      } else {
+        transitionMap.set(transitionKey, {
+          fromFeatureSet,
+          toFeatureSet,
+          fromKey,
+          toKey,
+          count: 1,
+        });
+      }
+    }
+
+    // -- Sort: count DESC, fromKey ASC, toKey ASC ------------------------------
+    const transitions = Array.from(transitionMap.values());
+
+    transitions.sort((a, b) => {
+      if (b.count !== a.count) return b.count - a.count;
+      if (a.fromKey !== b.fromKey) return a.fromKey.localeCompare(b.fromKey);
+      return a.toKey.localeCompare(b.toKey);
+    });
+
+    // -- Emit spec-canonical shape (fromFeatureSet / toFeatureSet arrays) ------
+    const transitionsOut = transitions.map(({ fromFeatureSet, toFeatureSet, count }) => ({
+      fromFeatureSet,
+      toFeatureSet,
+      count,
+    }));
+
+    return successResponse({
+      keywordTargetId:         id,
+      query,
+      locale,
+      device,
+      windowDays,
+      sampleSize,
+      totalTransitions:        sampleSize,         // invariant: sum(count) === sampleSize
+      distinctTransitionCount: transitions.length,
+      transitions:             transitionsOut,
+      computedAt:              requestTime.toISOString(),
+    });
+  } catch (err) {
+    console.error("GET /api/seo/keyword-targets/:id/feature-transitions error:", err);
+    return serverError();
+  }
+}


### PR DESCRIPTION
Implements SIL-8 A3 — Feature Transition Matrix for keyword-level SERP feature regime transitions.

Changes:
- Adds GET /api/seo/keyword-targets/[id]/feature-transitions
- Canonical feature set extraction (sorted, deterministic keys)
- Deterministic transition aggregation and sorting (count DESC, fromKey ASC, toKey ASC)
- Sum-check invariant: SUM(count) == sampleSize
- Adds hammer module scripts/hammer/hammer-sil8-a3.ps1
- Wires A3 hammer into scripts/api-hammer.ps1 parse-check and run block

Properties:
- Compute-on-read only (no schema changes, no writes)
- Project isolation enforced at DB boundary
- Deterministic outputs
- 282 PASS, build green
