### PR TITLE
feat(seo): add alert filtering and keyset pagination (SIL-9.1)

### DIFF
--- a/scripts/hammer/hammer-sil9.ps1
+++ b/scripts/hammer/hammer-sil9.ps1
@@ -1,11 +1,13 @@
 # hammer-sil9.ps1 -- SIL-9 Option A (Compute-on-Read Alerts MVP T1-T3)
+#                    + SIL-9.1 (Filtering + Keyset Pagination)
 # Dot-sourced by api-hammer.ps1. Inherits $Headers, $OtherHeaders, $Base, Hammer-Section, Hammer-Record.
 #
 # Endpoint: GET /api/seo/alerts
 #
-# Response shape (spec-canonical):
-#   alerts: AlertEmitted[], alertCount, totalAlerts, windowDays,
-#   spikeThreshold, concentrationThreshold, limit, computedAt
+# Response shape (SIL-9.1):
+#   alerts: AlertEmitted[], alertCount, totalAlerts,
+#   nextCursor: string|null, hasMore: boolean,
+#   windowDays, spikeThreshold, concentrationThreshold, limit, computedAt
 #
 # AlertEmitted union:
 #   T1: triggerType, keywordTargetId, query, fromRegime, toRegime,
@@ -16,26 +18,10 @@
 #       top3RiskKeywords, activeKeywordCount
 #
 # Fixture dependencies:
-#   $s3KtId        -- SIL-3 KeywordTarget with >=21 snapshots (set in hammer-sil3.ps1 or similar)
+#   $s3KtId        -- SIL-3 KeywordTarget with >=21 snapshots
 #   $OtherHeaders  -- second project headers (set in coordinator)
-#
-# Tests:
-#   SIL9-A: 400 if windowDays missing
-#   SIL9-B: 400 if windowDays out of range (0, 31)
-#   SIL9-C: 200 + required top-level fields present
-#   SIL9-D: determinism (two calls identical; ignore computedAt)
-#   SIL9-E: spikeThreshold=0 -> T2 alerts present when fixture has >=1 pair
-#   SIL9-F: T3 null guard -- totalVolatilitySum=0 context: no T3 alert
-#   SIL9-G: cross-project isolation (OtherHeaders -> 404)
-#   SIL9-H: alerts array shape -- each item has triggerType field
-#   SIL9-I: T2 alerts have required fields
-#   SIL9-J: T3 alert fields present (when T3 fires)
-#   SIL9-K: ordering deterministic -- two calls produce identical alert array
-#   SIL9-L: limit param respected (limit=1 returns at most 1 alert)
-#   SIL9-M: spikeThreshold=100 -> no T2 alerts (score cannot exceed 100)
-#   SIL9-N: concentrationThreshold=0.0 -> T3 fires if any active keyword exists with non-zero score
 
-Hammer-Section "SIL-9 TESTS (COMPUTE-ON-READ ALERT SURFACE - OPTION A MVP)"
+Hammer-Section "SIL-9 TESTS (COMPUTE-ON-READ ALERT SURFACE - OPTION A MVP + SIL-9.1)"
 
 $sil9Base = "/api/seo/alerts"
 
@@ -69,7 +55,7 @@ try {
     } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-C: 200 + required top-level fields ───────────────────────────────────
+# ── SIL9-C: 200 + required top-level fields (SIL-9.1: includes nextCursor, hasMore) ─
 try {
     Write-Host "Testing: SIL9-C /alerts 200 + required top-level fields present" -NoNewline
     $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30" `
@@ -77,7 +63,8 @@ try {
     if ($resp.StatusCode -eq 200) {
         $d    = ($resp.Content | ConvertFrom-Json).data
         $props = $d | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
-        $required = @("alerts","alertCount","totalAlerts","windowDays","spikeThreshold","concentrationThreshold","limit","computedAt")
+        $required = @("alerts","alertCount","totalAlerts","nextCursor","hasMore",
+                      "windowDays","spikeThreshold","concentrationThreshold","limit","computedAt")
         $missing  = $required | Where-Object { $props -notcontains $_ }
         if ($missing.Count -eq 0) {
             Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
@@ -96,14 +83,16 @@ try {
     if ($r1.StatusCode -eq 200 -and $r2.StatusCode -eq 200) {
         $d1 = ($r1.Content | ConvertFrom-Json).data
         $d2 = ($r2.Content | ConvertFrom-Json).data
-        # Compare everything except computedAt
         $a1 = ($d1.alerts | ConvertTo-Json -Depth 10 -Compress)
         $a2 = ($d2.alerts | ConvertTo-Json -Depth 10 -Compress)
+        $nc1 = $d1.nextCursor
+        $nc2 = $d2.nextCursor
         $countMatch = ($d1.alertCount -eq $d2.alertCount) -and ($d1.totalAlerts -eq $d2.totalAlerts)
-        if ($a1 -eq $a2 -and $countMatch) {
+        $cursorMatch = ($nc1 -eq $nc2)
+        if ($a1 -eq $a2 -and $countMatch -and $cursorMatch) {
             Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
         } else {
-            Write-Host "  FAIL (alert arrays differ between two calls)" -ForegroundColor Red; Hammer-Record FAIL
+            Write-Host "  FAIL (alert arrays or cursors differ between two calls)" -ForegroundColor Red; Hammer-Record FAIL
         }
     } else { Write-Host ("  FAIL (status=" + $r1.StatusCode + "/" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
@@ -122,37 +111,26 @@ try {
             if ($t2cnt -ge 1) {
                 Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
             } else {
-                # Could legitimately be zero if no snapshots in window
-                $ss = [int]$d.totalAlerts
-                Write-Host ("  SKIP (no T2 alerts with spikeThreshold=0; totalAlerts=" + $ss + "; may indicate no pairs in window)") -ForegroundColor DarkYellow; Hammer-Record SKIP
+                Write-Host ("  SKIP (no T2 alerts with spikeThreshold=0; totalAlerts=" + $d.totalAlerts + "; may indicate no pairs in window)") -ForegroundColor DarkYellow; Hammer-Record SKIP
             }
         } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
     }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-F: T3 null guard -- concentrationThreshold=0.0 with no active keywords ─
-# We test with a concentrationThreshold=0.0 (should fire if any active keyword exists
-# and totalVolatilitySum>0) but also verify no T3 if we can find the null-sum condition.
-# Since we cannot guarantee zero-sum in the main project, we verify the null guard
-# indirectly: request with concentrationThreshold=0.0 and check no T3 fires when
-# project has all-zero scores (data-dependent; SKIP if cannot confirm).
+# ── SIL9-F: T3 null guard ─────────────────────────────────────────────────────
 try {
     Write-Host "Testing: SIL9-F /alerts T3 null guard (no T3 when all scores zero)" -NoNewline
-    # Use a narrow windowDays with a project that likely has no snapshots in that 1-day window
-    # to get zero activeKeywordCount -> no T3 regardless of threshold
     $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=1&concentrationThreshold=0.0" `
         -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
     if ($resp.StatusCode -eq 200) {
         $d = ($resp.Content | ConvertFrom-Json).data
         $t3cnt = @($d.alerts | Where-Object { $_.triggerType -eq "T3" }).Count
-        # If no active keywords in 1-day window, no T3 should fire
         if ($t3cnt -eq 0) {
             Write-Host "  PASS (no T3 with likely empty 1-day window)" -ForegroundColor Green; Hammer-Record PASS
         } else {
-            # T3 fired because there ARE pairs in the 1-day window -- check ratio is non-null and > 0
             $t3 = $d.alerts | Where-Object { $_.triggerType -eq "T3" } | Select-Object -First 1
             if ($null -ne $t3.volatilityConcentrationRatio) {
-                Write-Host "  PASS (T3 fired legitimately with non-null ratio; null guard works by construction)" -ForegroundColor Green; Hammer-Record PASS
+                Write-Host "  PASS (T3 fired legitimately with non-null ratio)" -ForegroundColor Green; Hammer-Record PASS
             } else {
                 Write-Host "  FAIL (T3 fired with null volatilityConcentrationRatio)" -ForegroundColor Red; Hammer-Record FAIL
             }
@@ -160,35 +138,28 @@ try {
     } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-G: cross-project isolation -> 404 ────────────────────────────────────
+# ── SIL9-G: cross-project isolation ───────────────────────────────────────────
 try {
-    Write-Host "Testing: SIL9-G /alerts cross-project isolation (OtherHeaders -> 404 or empty)" -NoNewline
+    Write-Host "Testing: SIL9-G /alerts cross-project isolation (OtherHeaders)" -NoNewline
     if ($OtherHeaders.Count -eq 0) {
         Write-Host "  SKIP (OtherHeaders not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
     } else {
-        # /alerts is project-scope (no :id); resolveProjectId uses OtherHeaders to get other project.
-        # It should return 200 with that project's data (which may be empty), NOT 404.
-        # Isolation test: make sure main project's keyword data does NOT appear in other project's alerts.
         $respOther = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30" `
             -Method GET -Headers $OtherHeaders -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
         $respMain  = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30" `
             -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
         if ($respOther.StatusCode -eq 200 -and $respMain.StatusCode -eq 200) {
-            $dOther = ($respOther.Content | ConvertFrom-Json).data
-            $dMain  = ($respMain.Content  | ConvertFrom-Json).data
-            # Collect all keywordTargetIds in main project alerts
-            $mainKtIds = @($dMain.alerts | Where-Object { $_.keywordTargetId } | ForEach-Object { $_.keywordTargetId })
-            # Collect all keywordTargetIds in other project alerts
-            $otherKtIds = @($dOther.alerts | Where-Object { $_.keywordTargetId } | ForEach-Object { $_.keywordTargetId })
-            # No main project ktId should appear in other project response
+            $mainKtIds  = @($respMain.Content  | ConvertFrom-Json).data.alerts |
+                          Where-Object { $_.keywordTargetId } | ForEach-Object { $_.keywordTargetId }
+            $otherKtIds = @($respOther.Content | ConvertFrom-Json).data.alerts |
+                          Where-Object { $_.keywordTargetId } | ForEach-Object { $_.keywordTargetId }
             $leaked = $mainKtIds | Where-Object { $otherKtIds -contains $_ }
             if ($leaked.Count -eq 0) {
                 Write-Host "  PASS (no cross-project leakage)" -ForegroundColor Green; Hammer-Record PASS
             } else {
-                Write-Host ("  FAIL (" + $leaked.Count + " keywordTargetIds leaked to other project response)") -ForegroundColor Red; Hammer-Record FAIL
+                Write-Host ("  FAIL (" + $leaked.Count + " keywordTargetIds leaked)") -ForegroundColor Red; Hammer-Record FAIL
             }
         } elseif ($respOther.StatusCode -eq 404) {
-            # Acceptable: other project not found
             Write-Host "  PASS (other project 404 — isolation enforced)" -ForegroundColor Green; Hammer-Record PASS
         } else {
             Write-Host ("  FAIL (other=" + $respOther.StatusCode + " main=" + $respMain.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL
@@ -196,48 +167,40 @@ try {
     }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-H: alerts array items have triggerType field ─────────────────────────
+# ── SIL9-H: alerts array items have valid triggerType ─────────────────────────
 try {
-    Write-Host "Testing: SIL9-H /alerts each item has triggerType field" -NoNewline
+    Write-Host "Testing: SIL9-H /alerts each item has valid triggerType" -NoNewline
     $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30" `
         -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
     if ($resp.StatusCode -eq 200) {
-        $d = ($resp.Content | ConvertFrom-Json).data
-        $items = @($d.alerts)
+        $items = @(($resp.Content | ConvertFrom-Json).data.alerts)
         if ($items.Count -eq 0) {
-            Write-Host "  SKIP (no alerts returned; cannot verify field)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            Write-Host "  SKIP (no alerts returned)" -ForegroundColor DarkYellow; Hammer-Record SKIP
         } else {
-            $missingType = $items | Where-Object { -not $_.triggerType }
-            if ($missingType.Count -eq 0) {
-                $validTypes = $items | Where-Object { @("T1","T2","T3") -contains $_.triggerType }
-                if ($validTypes.Count -eq $items.Count) {
-                    Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
-                } else {
-                    Write-Host "  FAIL (some triggerType values are not T1/T2/T3)" -ForegroundColor Red; Hammer-Record FAIL
-                }
+            $invalid = $items | Where-Object { @("T1","T2","T3") -notcontains $_.triggerType }
+            if ($invalid.Count -eq 0) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
             } else {
-                Write-Host ("  FAIL (" + $missingType.Count + " items missing triggerType)") -ForegroundColor Red; Hammer-Record FAIL
+                Write-Host ("  FAIL (" + $invalid.Count + " items with invalid triggerType)") -ForegroundColor Red; Hammer-Record FAIL
             }
         }
     } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-I: T2 alerts have required fields ────────────────────────────────────
+# ── SIL9-I: T2 required fields ────────────────────────────────────────────────
 try {
     Write-Host "Testing: SIL9-I /alerts T2 items have required fields" -NoNewline
     $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&spikeThreshold=0" `
         -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
     if ($resp.StatusCode -eq 200) {
-        $d    = ($resp.Content | ConvertFrom-Json).data
-        $t2s  = @($d.alerts | Where-Object { $_.triggerType -eq "T2" })
+        $t2s = @(($resp.Content | ConvertFrom-Json).data.alerts | Where-Object { $_.triggerType -eq "T2" })
         if ($t2s.Count -eq 0) {
-            Write-Host "  SKIP (no T2 alerts returned)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            Write-Host "  SKIP (no T2 alerts)" -ForegroundColor DarkYellow; Hammer-Record SKIP
         } else {
-            $t2         = $t2s[0]
-            $t2Props    = $t2 | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
-            $required   = @("triggerType","keywordTargetId","query","fromSnapshotId","toSnapshotId",
-                            "fromCapturedAt","toCapturedAt","pairVolatilityScore","threshold","exceedanceMargin")
-            $missing    = $required | Where-Object { $t2Props -notcontains $_ }
+            $t2Props  = $t2s[0] | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+            $required = @("triggerType","keywordTargetId","query","fromSnapshotId","toSnapshotId",
+                          "fromCapturedAt","toCapturedAt","pairVolatilityScore","threshold","exceedanceMargin")
+            $missing  = $required | Where-Object { $t2Props -notcontains $_ }
             if ($missing.Count -eq 0) {
                 Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
             } else {
@@ -247,19 +210,17 @@ try {
     } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-J: T3 alert fields present (when T3 fires) ──────────────────────────
+# ── SIL9-J: T3 fields present when T3 fires ───────────────────────────────────
 try {
     Write-Host "Testing: SIL9-J /alerts T3 fields present when T3 fires" -NoNewline
     $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&concentrationThreshold=0.0" `
         -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
     if ($resp.StatusCode -eq 200) {
-        $d   = ($resp.Content | ConvertFrom-Json).data
-        $t3s = @($d.alerts | Where-Object { $_.triggerType -eq "T3" })
+        $t3s = @(($resp.Content | ConvertFrom-Json).data.alerts | Where-Object { $_.triggerType -eq "T3" })
         if ($t3s.Count -eq 0) {
-            Write-Host "  SKIP (no T3 alerts returned; may be zero active keywords in window)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            Write-Host "  SKIP (no T3 alerts)" -ForegroundColor DarkYellow; Hammer-Record SKIP
         } else {
-            $t3      = $t3s[0]
-            $t3Props = $t3 | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+            $t3Props  = $t3s[0] | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
             $required = @("triggerType","projectId","volatilityConcentrationRatio","threshold","top3RiskKeywords","activeKeywordCount")
             $missing  = $required | Where-Object { $t3Props -notcontains $_ }
             if ($missing.Count -eq 0) {
@@ -271,7 +232,7 @@ try {
     } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-K: ordering -- two calls produce identical alert order ───────────────
+# ── SIL9-K: ordering stable across two calls ──────────────────────────────────
 try {
     Write-Host "Testing: SIL9-K /alerts ordering stable across two calls" -NoNewline
     $url = "$Base$sil9Base`?windowDays=30&spikeThreshold=0"
@@ -283,7 +244,7 @@ try {
         if ($arr1 -eq $arr2) {
             Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
         } else {
-            Write-Host "  FAIL (alert array order differs between two calls)" -ForegroundColor Red; Hammer-Record FAIL
+            Write-Host "  FAIL (alert array order differs)" -ForegroundColor Red; Hammer-Record FAIL
         }
     } else { Write-Host ("  FAIL (status=" + $r1.StatusCode + "/" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
@@ -294,51 +255,274 @@ try {
     $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&spikeThreshold=0&limit=1" `
         -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
     if ($resp.StatusCode -eq 200) {
-        $d   = ($resp.Content | ConvertFrom-Json).data
-        $cnt = @($d.alerts).Count
+        $cnt = @(($resp.Content | ConvertFrom-Json).data.alerts).Count
         if ($cnt -le 1) {
             Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
         } else {
-            Write-Host ("  FAIL (alertCount=" + $cnt + ", expected <= 1)") -ForegroundColor Red; Hammer-Record FAIL
+            Write-Host ("  FAIL (alerts.Count=" + $cnt + ", expected <= 1)") -ForegroundColor Red; Hammer-Record FAIL
         }
     } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-M: spikeThreshold=100 -> no T2 alerts (score <= 100 always) ─────────
+# ── SIL9-M: spikeThreshold=100 -> no T2 alerts ───────────────────────────────
 try {
     Write-Host "Testing: SIL9-M /alerts spikeThreshold=100 produces no T2 alerts" -NoNewline
     $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&spikeThreshold=100" `
         -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
     if ($resp.StatusCode -eq 200) {
-        $d    = ($resp.Content | ConvertFrom-Json).data
-        $t2s  = @($d.alerts | Where-Object { $_.triggerType -eq "T2" })
-        if ($t2s.Count -eq 0) {
-            Write-Host "  PASS (no T2 alerts with spikeThreshold=100)" -ForegroundColor Green; Hammer-Record PASS
+        $t2cnt = @(($resp.Content | ConvertFrom-Json).data.alerts | Where-Object { $_.triggerType -eq "T2" }).Count
+        if ($t2cnt -eq 0) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
         } else {
-            Write-Host ("  FAIL (" + $t2s.Count + " T2 alerts returned with spikeThreshold=100; score cannot exceed 100)") -ForegroundColor Red; Hammer-Record FAIL
+            Write-Host ("  FAIL (" + $t2cnt + " T2 alerts with spikeThreshold=100)") -ForegroundColor Red; Hammer-Record FAIL
         }
     } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
-# ── SIL9-N: concentrationThreshold=0.0 -> T3 fires if activeKeywordCount > 0 ─
+# ── SIL9-N: concentrationThreshold=0.0 fires T3 when active keywords exist ───
 try {
     Write-Host "Testing: SIL9-N /alerts concentrationThreshold=0.0 fires T3 when active keywords exist" -NoNewline
     $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&concentrationThreshold=0.0" `
         -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
     if ($resp.StatusCode -eq 200) {
-        $d     = ($resp.Content | ConvertFrom-Json).data
-        $t3cnt = @($d.alerts | Where-Object { $_.triggerType -eq "T3" }).Count
-        if ($t3cnt -ge 1) {
-            $t3 = $d.alerts | Where-Object { $_.triggerType -eq "T3" } | Select-Object -First 1
-            # ratio must be non-null (null guard: if ratio is null, T3 should not have fired)
-            if ($null -ne $t3.volatilityConcentrationRatio) {
+        $t3s = @(($resp.Content | ConvertFrom-Json).data.alerts | Where-Object { $_.triggerType -eq "T3" })
+        if ($t3s.Count -ge 1) {
+            if ($null -ne $t3s[0].volatilityConcentrationRatio) {
                 Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
             } else {
-                Write-Host "  FAIL (T3 fired with null volatilityConcentrationRatio -- null guard violated)" -ForegroundColor Red; Hammer-Record FAIL
+                Write-Host "  FAIL (T3 fired with null ratio)" -ForegroundColor Red; Hammer-Record FAIL
             }
         } else {
-            # T3 didn't fire -- acceptable if no active keywords in 30-day window
-            Write-Host "  SKIP (no T3 alert; may be no active keywords in 30-day window)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+            Write-Host "  SKIP (no T3; may be no active keywords in 30-day window)" -ForegroundColor DarkYellow; Hammer-Record SKIP
         }
     } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# =============================================================================
+# SIL-9.1: PAGINATION TESTS
+# =============================================================================
+
+Hammer-Section "SIL-9.1 TESTS (FILTERING + KEYSET PAGINATION)"
+
+# ── SIL9-P1: limit=1 returns exactly 1 alert AND non-null nextCursor when more exist ─
+try {
+    Write-Host "Testing: SIL9-P1 /alerts limit=1 returns nextCursor when more exist" -NoNewline
+    # Use spikeThreshold=0 to maximize alert count
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&spikeThreshold=0&limit=1" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $d    = ($resp.Content | ConvertFrom-Json).data
+        $cnt  = @($d.alerts).Count
+        $tot  = [int]$d.totalAlerts
+        $nc   = $d.nextCursor
+        $more = $d.hasMore
+        if ($tot -le 1) {
+            Write-Host "  SKIP (totalAlerts <= 1; cannot verify nextCursor behavior)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+        } elseif ($cnt -eq 1 -and $null -ne $nc -and $more -eq $true) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else {
+            Write-Host ("  FAIL (cnt=" + $cnt + " nextCursor=" + $nc + " hasMore=" + $more + " totalAlerts=" + $tot + ")") -ForegroundColor Red; Hammer-Record FAIL
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-P2: using nextCursor returns next item and does NOT repeat the first ─
+try {
+    Write-Host "Testing: SIL9-P2 /alerts cursor advances without repeating first item" -NoNewline
+    $url1 = "$Base$sil9Base`?windowDays=30&spikeThreshold=0&limit=1"
+    $r1   = Invoke-WebRequest -Uri $url1 -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($r1.StatusCode -ne 200) {
+        Write-Host ("  FAIL (page1 status=" + $r1.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL
+    } else {
+        $d1  = ($r1.Content | ConvertFrom-Json).data
+        $nc1 = $d1.nextCursor
+        $tot = [int]$d1.totalAlerts
+        if ($tot -lt 2 -or $null -eq $nc1) {
+            Write-Host "  SKIP (fewer than 2 alerts or no nextCursor; cannot verify)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+        } else {
+            $url2 = "$Base$sil9Base`?windowDays=30&spikeThreshold=0&limit=1&cursor=$([System.Uri]::EscapeDataString($nc1))"
+            $r2   = Invoke-WebRequest -Uri $url2 -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+            if ($r2.StatusCode -ne 200) {
+                Write-Host ("  FAIL (page2 status=" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL
+            } else {
+                $d2      = ($r2.Content | ConvertFrom-Json).data
+                $items1  = @($d1.alerts)
+                $items2  = @($d2.alerts)
+                if ($items2.Count -eq 0) {
+                    Write-Host "  FAIL (page2 returned 0 items but totalAlerts=" + $tot + ")" -ForegroundColor Red; Hammer-Record FAIL
+                } else {
+                    # The first item on page2 must differ from the first item on page1
+                    $p1json = ($items1[0] | ConvertTo-Json -Depth 10 -Compress)
+                    $p2json = ($items2[0] | ConvertTo-Json -Depth 10 -Compress)
+                    if ($p1json -ne $p2json) {
+                        Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+                    } else {
+                        Write-Host "  FAIL (page2 item[0] is identical to page1 item[0] — duplication)" -ForegroundColor Red; Hammer-Record FAIL
+                    }
+                }
+            }
+        }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-P3: determinism — same query + same cursor yields identical results ──
+try {
+    Write-Host "Testing: SIL9-P3 /alerts same cursor yields identical results (determinism)" -NoNewline
+    $url1 = "$Base$sil9Base`?windowDays=30&spikeThreshold=0&limit=1"
+    $r1   = Invoke-WebRequest -Uri $url1 -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($r1.StatusCode -ne 200) {
+        Write-Host ("  FAIL (page1 status=" + $r1.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL
+    } else {
+        $nc1 = ($r1.Content | ConvertFrom-Json).data.nextCursor
+        if ($null -eq $nc1) {
+            Write-Host "  SKIP (no nextCursor; only 1 or 0 alerts)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+        } else {
+            $url2 = "$Base$sil9Base`?windowDays=30&spikeThreshold=0&limit=1&cursor=$([System.Uri]::EscapeDataString($nc1))"
+            $rA   = Invoke-WebRequest -Uri $url2 -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+            $rB   = Invoke-WebRequest -Uri $url2 -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+            if ($rA.StatusCode -eq 200 -and $rB.StatusCode -eq 200) {
+                $jsonA = ($rA.Content | ConvertFrom-Json).data.alerts | ConvertTo-Json -Depth 10 -Compress
+                $jsonB = ($rB.Content | ConvertFrom-Json).data.alerts | ConvertTo-Json -Depth 10 -Compress
+                if ($jsonA -eq $jsonB) {
+                    Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+                } else {
+                    Write-Host "  FAIL (same cursor produced different results on two calls)" -ForegroundColor Red; Hammer-Record FAIL
+                }
+            } else {
+                Write-Host ("  FAIL (page2 status=" + $rA.StatusCode + "/" + $rB.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# =============================================================================
+# SIL-9.1: FILTER TESTS
+# =============================================================================
+
+# ── SIL9-F1: triggerTypes=T3 returns only T3 alerts (or empty) ───────────────
+try {
+    Write-Host "Testing: SIL9-F1 /alerts triggerTypes=T3 returns only T3 (or empty)" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&triggerTypes=T3&concentrationThreshold=0.0" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $items = @(($resp.Content | ConvertFrom-Json).data.alerts)
+        $nonT3 = $items | Where-Object { $_.triggerType -ne "T3" }
+        if ($nonT3.Count -eq 0) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else {
+            Write-Host ("  FAIL (" + $nonT3.Count + " non-T3 alerts returned with triggerTypes=T3)") -ForegroundColor Red; Hammer-Record FAIL
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-F2: keywordTargetId=<known> returns only alerts for that keyword, omits T3 ─
+try {
+    Write-Host "Testing: SIL9-F2 /alerts keywordTargetId filter excludes T3 and other keywords" -NoNewline
+    if ([string]::IsNullOrWhiteSpace($s3KtId)) {
+        Write-Host "  SKIP (s3KtId not available)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+    } else {
+        $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&spikeThreshold=0&keywordTargetId=$s3KtId" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -eq 200) {
+            $items  = @(($resp.Content | ConvertFrom-Json).data.alerts)
+            $t3s    = $items | Where-Object { $_.triggerType -eq "T3" }
+            $badKts = $items | Where-Object { $_.triggerType -ne "T3" -and $_.keywordTargetId -ne $s3KtId }
+            $fail   = $false
+            $msg    = ""
+            if ($t3s.Count -gt 0) {
+                $fail = $true
+                $msg  = "T3 returned despite keywordTargetId filter (" + $t3s.Count + ")"
+            }
+            if ($badKts.Count -gt 0) {
+                $fail = $true
+                $msg  = $msg + " wrong keywordTargetIds returned (" + $badKts.Count + ")"
+            }
+            if (-not $fail) {
+                Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+            } else {
+                Write-Host ("  FAIL (" + $msg.Trim() + ")") -ForegroundColor Red; Hammer-Record FAIL
+            }
+        } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-F3: minSeverityRank filters out lower severityRank items ─────────────
+# T3=7, T2=6, T1=1-5. minSeverityRank=7 should return only T3 (if any) and T3-only.
+try {
+    Write-Host "Testing: SIL9-F3 /alerts minSeverityRank=7 returns only rank>=7 alerts" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&spikeThreshold=0&minSeverityRank=7&concentrationThreshold=0.0" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $items = @(($resp.Content | ConvertFrom-Json).data.alerts)
+        # We can't directly see severityRank (it's stripped), but we can verify:
+        # No T1 (max rank 5) and no T2 (rank 6) should appear when minSeverityRank=7
+        $t1s = $items | Where-Object { $_.triggerType -eq "T1" }
+        $t2s = $items | Where-Object { $_.triggerType -eq "T2" }
+        if ($t1s.Count -eq 0 -and $t2s.Count -eq 0) {
+            Write-Host "  PASS (no T1/T2 with minSeverityRank=7)" -ForegroundColor Green; Hammer-Record PASS
+        } else {
+            Write-Host ("  FAIL (T1=" + $t1s.Count + " T2=" + $t2s.Count + " returned with minSeverityRank=7)") -ForegroundColor Red; Hammer-Record FAIL
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-F4: minPairVolatilityScore=100 yields no T2 alerts ──────────────────
+try {
+    Write-Host "Testing: SIL9-F4 /alerts minPairVolatilityScore=100 yields no T2 alerts" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&spikeThreshold=0&minPairVolatilityScore=100" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $t2cnt = @(($resp.Content | ConvertFrom-Json).data.alerts | Where-Object { $_.triggerType -eq "T2" }).Count
+        if ($t2cnt -eq 0) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else {
+            Write-Host ("  FAIL (" + $t2cnt + " T2 alerts with minPairVolatilityScore=100)") -ForegroundColor Red; Hammer-Record FAIL
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# =============================================================================
+# SIL-9.1: VALIDATION TESTS
+# =============================================================================
+
+# ── SIL9-V1: invalid triggerTypes token -> 400 ────────────────────────────────
+try {
+    Write-Host "Testing: SIL9-V1 /alerts invalid triggerTypes token -> 400" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&triggerTypes=T1,TX" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 400) {
+        Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-V2: invalid cursor -> 400 ───────────────────────────────────────────
+try {
+    Write-Host "Testing: SIL9-V2 /alerts invalid cursor -> 400" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&cursor=not-valid-base64-json!!" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 400) {
+        Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-V2b: structurally valid base64 but semantically invalid cursor -> 400 ─
+try {
+    Write-Host "Testing: SIL9-V2b /alerts base64 cursor with bad JSON fields -> 400" -NoNewline
+    # Encode JSON that is valid base64url but missing required cursor fields
+    $badPayload = [System.Convert]::ToBase64String([System.Text.Encoding]::UTF8.GetBytes('{"x":1}')) -replace '\+','-' -replace '/','_' -replace '=',''
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&cursor=$badPayload" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 400) {
+        Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-V3: invalid keywordTargetId -> 400 ──────────────────────────────────
+try {
+    Write-Host "Testing: SIL9-V3 /alerts invalid keywordTargetId -> 400" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&keywordTargetId=not-a-uuid" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 400) {
+        Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }

--- a/src/app/api/seo/alerts/route.ts
+++ b/src/app/api/seo/alerts/route.ts
@@ -1,6 +1,8 @@
 /**
  * GET /api/seo/alerts — SIL-9 Option A: Compute-on-Read Alert Surface (MVP T1–T3)
  *
+ * SIL-9.1 additions: alert filtering + deterministic keyset pagination.
+ *
  * Returns deterministic alert records derived from snapshot history.
  * No writes. No EventLog. No schema changes. No background jobs.
  * All trigger conditions are functions of included snapshot rows only.
@@ -18,17 +20,30 @@
  *         (B2 formula) > concentrationThreshold and is non-null.
  *
  * Query params:
- *   windowDays            required   integer 1–30
- *   spikeThreshold        optional   float 0–100, default 75.00
- *   concentrationThreshold optional  float 0–1,   default 0.80
- *   limit                 optional   integer 1–200, default 100
+ *   windowDays             required  integer 1–30
+ *   spikeThreshold         optional  float 0–100,  default 75.00
+ *   concentrationThreshold optional  float 0–1,    default 0.80
+ *   limit                  optional  integer 1–200, default 100
+ *   cursor                 optional  opaque base64url string (keyset pagination)
  *
- * Deterministic ordering (per SIL-9 spec):
- *   1. severityRank DESC  (derived from trigger type + regime transition map)
- *   2. toCapturedAt DESC  (for keyword alerts; for T3 = latestCapturedAt in window)
+ * SIL-9.1 filter params (all optional, all validated before any DB work):
+ *   triggerTypes           comma-separated subset of T1,T2,T3
+ *                          If absent → all types returned.
+ *                          If keywordTargetId present → T3 automatically excluded.
+ *   keywordTargetId        UUID — filters to alerts for a single keyword;
+ *                          T3 (project-scope) is excluded when this is present.
+ *   minSeverityRank        integer 0–999 — excludes alerts with severityRank below this.
+ *   minPairVolatilityScore float 0–100 — only applied to T2 alerts; T1/T3 unaffected.
+ *
+ * Deterministic ordering (unchanged from SIL-9):
+ *   1. severityRank DESC
+ *   2. toCapturedAt DESC
  *   3. triggerType ASC
  *   4. keywordTargetId ASC (nulls last)
  *   5. toSnapshotId DESC  (nulls last)
+ *
+ * Keyset cursor encodes all five sort key fields as base64url JSON.
+ * isAfterCursor() mirrors compareAlerts() exactly.
  *
  * Isolation: resolveProjectId(request) — headers only.
  *   /alerts is a project-scope endpoint; no :id in path; all data scoped to resolved projectId.
@@ -64,6 +79,15 @@ const LIMIT_DEFAULT = 100;
 const LIMIT_MIN     = 1;
 const LIMIT_MAX     = 200;
 
+const MIN_SEVERITY_RANK_MIN = 0;
+const MIN_SEVERITY_RANK_MAX = 999;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+const VALID_TRIGGER_TYPES = new Set(["T1", "T2", "T3"] as const);
+type TriggerTypeToken = "T1" | "T2" | "T3";
+
 // =============================================================================
 // Severity rank — derived from trigger type + regime transition direction.
 // Higher rank = higher severity. Never stored; always derived at sort time.
@@ -90,12 +114,12 @@ function t1SeverityRank(fromRegime: VolatilityRegime, toRegime: VolatilityRegime
   // Escalation: rank by destination regime and jump distance
   const jump = to - from;
   if (to === 3) {
-    // → chaotic
-    return jump >= 3 ? 5 : jump === 2 ? 5 : 4; // calm→chaotic or shifting→chaotic = 5, unstable→chaotic = 4
+    // → chaotic: calm→chaotic or shifting→chaotic = 5, unstable→chaotic = 4
+    return jump >= 2 ? 5 : 4;
   }
   if (to === 2) {
-    // → unstable
-    return jump === 2 ? 4 : 3; // calm→unstable = 4, shifting→unstable = 3
+    // → unstable: calm→unstable = 4, shifting→unstable = 3
+    return jump === 2 ? 4 : 3;
   }
   // → shifting (calm→shifting) = 2
   return 2;
@@ -142,31 +166,190 @@ interface T2Alert {
 }
 
 interface T3Alert {
-  triggerType:                 "T3";
-  projectId:                   string;
+  triggerType:                  "T3";
+  projectId:                    string;
   volatilityConcentrationRatio: number;
-  threshold:                   number;
-  top3RiskKeywords:            Array<{
-    keywordTargetId: string;
-    query:           string;
-    volatilityScore: number;
+  threshold:                    number;
+  top3RiskKeywords:             Array<{
+    keywordTargetId:  string;
+    query:            string;
+    volatilityScore:  number;
     volatilityRegime: VolatilityRegime;
   }>;
   activeKeywordCount: number;
   // sort-assist (latestCapturedAt in window, used as toCapturedAt equivalent)
-  _severityRank:      number;
-  _toCapturedAtMs:    number;
-  _toSnapshotId:      null;
-  _keywordTargetId:   null;
+  _severityRank:     number;
+  _toCapturedAtMs:   number;
+  _toSnapshotId:     null;
+  _keywordTargetId:  null;
 }
 
 type AnyAlert = T1Alert | T2Alert | T3Alert;
 
 // Emitted shapes (sort-assist fields stripped)
-type T1Emitted  = Omit<T1Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
-type T2Emitted  = Omit<T2Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
-type T3Emitted  = Omit<T3Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
+type T1Emitted    = Omit<T1Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
+type T2Emitted    = Omit<T2Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
+type T3Emitted    = Omit<T3Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
 type AlertEmitted = T1Emitted | T2Emitted | T3Emitted;
+
+// =============================================================================
+// Cursor
+//
+// Payload fields (abbreviated keys for compactness):
+//   s  — severityRank (number)
+//   t  — toCapturedAtMs (number, unix ms)
+//   tt — triggerType ("T1" | "T2" | "T3")
+//   k  — keywordTargetId (string | null)
+//   sn — toSnapshotId (string | null)
+//
+// Encoded as base64url(JSON.stringify(payload)).
+// Decoded payload is validated before use; malformed → 400.
+// =============================================================================
+
+interface CursorPayload {
+  s:  number;
+  t:  number;
+  tt: TriggerTypeToken;
+  k:  string | null;
+  sn: string | null;
+}
+
+function encodeCursor(alert: AnyAlert): string {
+  const payload: CursorPayload = {
+    s:  alert._severityRank,
+    t:  alert._toCapturedAtMs,
+    tt: alert.triggerType,
+    k:  alert._keywordTargetId,
+    sn: alert._toSnapshotId,
+  };
+  return Buffer.from(JSON.stringify(payload), "utf8").toString("base64url");
+}
+
+function decodeCursor(
+  raw: string
+): { payload: CursorPayload } | { error: string } {
+  try {
+    const json = Buffer.from(raw, "base64url").toString("utf8");
+    const p = JSON.parse(json) as Record<string, unknown>;
+    if (
+      typeof p.s  !== "number" ||
+      typeof p.t  !== "number" ||
+      typeof p.tt !== "string" ||
+      !VALID_TRIGGER_TYPES.has(p.tt as TriggerTypeToken) ||
+      (p.k  !== null && typeof p.k  !== "string") ||
+      (p.sn !== null && typeof p.sn !== "string")
+    ) {
+      return { error: "cursor is invalid: missing or malformed fields" };
+    }
+    return {
+      payload: {
+        s:  p.s  as number,
+        t:  p.t  as number,
+        tt: p.tt as TriggerTypeToken,
+        k:  p.k  as string | null,
+        sn: p.sn as string | null,
+      },
+    };
+  } catch {
+    return { error: "cursor is invalid: not valid base64url JSON" };
+  }
+}
+
+// =============================================================================
+// Deterministic sort comparator
+//
+// Order (per SIL-9 spec — unchanged in SIL-9.1):
+//   1. severityRank DESC
+//   2. toCapturedAt DESC
+//   3. triggerType ASC
+//   4. keywordTargetId ASC (nulls last)
+//   5. toSnapshotId DESC (nulls last)
+// =============================================================================
+
+function compareAlerts(a: AnyAlert, b: AnyAlert): number {
+  // 1. severityRank DESC
+  if (b._severityRank !== a._severityRank) return b._severityRank - a._severityRank;
+  // 2. toCapturedAt DESC
+  if (b._toCapturedAtMs !== a._toCapturedAtMs) return b._toCapturedAtMs - a._toCapturedAtMs;
+  // 3. triggerType ASC
+  if (a.triggerType < b.triggerType) return -1;
+  if (a.triggerType > b.triggerType) return 1;
+  // 4. keywordTargetId ASC (nulls last)
+  const aKtId = a._keywordTargetId;
+  const bKtId = b._keywordTargetId;
+  if (aKtId === null && bKtId === null) {
+    // both null — proceed to next key
+  } else if (aKtId === null) {
+    return 1;
+  } else if (bKtId === null) {
+    return -1;
+  } else {
+    const cmp = aKtId.localeCompare(bKtId);
+    if (cmp !== 0) return cmp;
+  }
+  // 5. toSnapshotId DESC (nulls last)
+  const aSnId = a._toSnapshotId;
+  const bSnId = b._toSnapshotId;
+  if (aSnId === null && bSnId === null) return 0;
+  if (aSnId === null) return 1;
+  if (bSnId === null) return -1;
+  if (bSnId > aSnId) return 1;
+  if (bSnId < aSnId) return -1;
+  return 0;
+}
+
+// =============================================================================
+// isAfterCursor — returns true when alert comes strictly AFTER cursor position
+// in the total ordering defined by compareAlerts.
+//
+// This mirrors compareAlerts key-by-key. "After" in DESC fields means smaller
+// value; "after" in ASC fields means larger value. Nulls-last rules preserved.
+//
+// CRITICAL: must stay in sync with compareAlerts. If the sort order changes,
+// this function must change too.
+// =============================================================================
+
+function isAfterCursor(alert: AnyAlert, cur: CursorPayload): boolean {
+  // 1. severityRank DESC — after means alert.s < cur.s
+  if (alert._severityRank !== cur.s) return alert._severityRank < cur.s;
+
+  // 2. toCapturedAt DESC — after means alert.t < cur.t
+  if (alert._toCapturedAtMs !== cur.t) return alert._toCapturedAtMs < cur.t;
+
+  // 3. triggerType ASC — after means alert.tt > cur.tt
+  if (alert.triggerType !== cur.tt) return alert.triggerType > cur.tt;
+
+  // 4. keywordTargetId ASC (nulls last)
+  const ak = alert._keywordTargetId;
+  const ck = cur.k;
+  if (ak !== ck) {
+    if (ak === null) return true;   // null is last → alert comes after non-null cursor
+    if (ck === null) return false;  // alert is non-null, cursor is null → alert comes before
+    return ak.localeCompare(ck) > 0;
+  }
+
+  // 5. toSnapshotId DESC (nulls last)
+  const asn = alert._toSnapshotId;
+  const csn = cur.sn;
+  if (asn !== csn) {
+    if (asn === null) return true;  // null is last → after
+    if (csn === null) return false;
+    return asn < csn; // DESC — after means smaller string
+  }
+
+  // Exact match on all keys — not strictly after
+  return false;
+}
+
+// =============================================================================
+// Strip sort-assist fields before returning to client
+// =============================================================================
+
+function stripSortFields(alert: AnyAlert): AlertEmitted {
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { _severityRank, _toCapturedAtMs, _toSnapshotId, _keywordTargetId, ...emitted } = alert;
+  return emitted as AlertEmitted;
+}
 
 // =============================================================================
 // Param parsers
@@ -220,57 +403,66 @@ function parseLimit(
   return { limit: n };
 }
 
-// =============================================================================
-// Deterministic sort comparator
-//
-// Order (per SIL-9 spec):
-//   1. severityRank DESC
-//   2. toCapturedAt DESC
-//   3. triggerType ASC
-//   4. keywordTargetId ASC (nulls last)
-//   5. toSnapshotId DESC (nulls last)
-// =============================================================================
-
-function compareAlerts(a: AnyAlert, b: AnyAlert): number {
-  // 1. severityRank DESC
-  if (b._severityRank !== a._severityRank) return b._severityRank - a._severityRank;
-  // 2. toCapturedAt DESC
-  if (b._toCapturedAtMs !== a._toCapturedAtMs) return b._toCapturedAtMs - a._toCapturedAtMs;
-  // 3. triggerType ASC
-  if (a.triggerType < b.triggerType) return -1;
-  if (a.triggerType > b.triggerType) return 1;
-  // 4. keywordTargetId ASC (nulls last)
-  const aKtId = a._keywordTargetId;
-  const bKtId = b._keywordTargetId;
-  if (aKtId === null && bKtId === null) {
-    // both null — proceed to next key
-  } else if (aKtId === null) {
-    return 1; // a goes after b
-  } else if (bKtId === null) {
-    return -1;
-  } else {
-    const cmp = aKtId.localeCompare(bKtId);
-    if (cmp !== 0) return cmp;
+function parseTriggerTypes(
+  sp: URLSearchParams
+): { triggerTypes: Set<TriggerTypeToken> | null } | { error: string } {
+  const raw = sp.get("triggerTypes");
+  if (raw === null) return { triggerTypes: null }; // null = no filter, all types
+  const tokens = raw.split(",").map((t) => t.trim());
+  if (tokens.length === 0 || (tokens.length === 1 && tokens[0] === "")) {
+    return { error: "triggerTypes must not be empty" };
   }
-  // 5. toSnapshotId DESC (nulls last)
-  const aSnId = a._toSnapshotId;
-  const bSnId = b._toSnapshotId;
-  if (aSnId === null && bSnId === null) return 0;
-  if (aSnId === null) return 1;
-  if (bSnId === null) return -1;
-  if (bSnId > aSnId) return 1;
-  if (bSnId < aSnId) return -1;
-  return 0;
+  const set = new Set<TriggerTypeToken>();
+  for (const token of tokens) {
+    if (!VALID_TRIGGER_TYPES.has(token as TriggerTypeToken)) {
+      return { error: `triggerTypes contains invalid token: "${token}". Valid values: T1, T2, T3` };
+    }
+    set.add(token as TriggerTypeToken);
+  }
+  return { triggerTypes: set };
 }
 
-// =============================================================================
-// Strip sort-assist fields before returning to client
-// =============================================================================
+function parseKeywordTargetId(
+  sp: URLSearchParams
+): { keywordTargetId: string | null } | { error: string } {
+  const raw = sp.get("keywordTargetId");
+  if (raw === null) return { keywordTargetId: null };
+  if (!UUID_RE.test(raw)) return { error: "keywordTargetId must be a valid UUID" };
+  return { keywordTargetId: raw };
+}
 
-function stripSortFields(alert: AnyAlert): AlertEmitted {
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { _severityRank, _toCapturedAtMs, _toSnapshotId, _keywordTargetId, ...emitted } = alert;
-  return emitted as AlertEmitted;
+function parseMinSeverityRank(
+  sp: URLSearchParams
+): { minSeverityRank: number | null } | { error: string } {
+  const raw = sp.get("minSeverityRank");
+  if (raw === null) return { minSeverityRank: null };
+  if (!/^\d+$/.test(raw)) return { error: "minSeverityRank must be an integer" };
+  const n = parseInt(raw, 10);
+  if (n < MIN_SEVERITY_RANK_MIN) return { error: `minSeverityRank must be >= ${MIN_SEVERITY_RANK_MIN}` };
+  if (n > MIN_SEVERITY_RANK_MAX) return { error: `minSeverityRank must be <= ${MIN_SEVERITY_RANK_MAX}` };
+  return { minSeverityRank: n };
+}
+
+function parseMinPairVolatilityScore(
+  sp: URLSearchParams
+): { minPairVolatilityScore: number | null } | { error: string } {
+  const raw = sp.get("minPairVolatilityScore");
+  if (raw === null) return { minPairVolatilityScore: null };
+  const n = parseFloat(raw);
+  if (isNaN(n)) return { error: "minPairVolatilityScore must be a number" };
+  if (n < 0)   return { error: "minPairVolatilityScore must be >= 0" };
+  if (n > 100) return { error: "minPairVolatilityScore must be <= 100" };
+  return { minPairVolatilityScore: n };
+}
+
+function parseCursor(
+  sp: URLSearchParams
+): { cursor: CursorPayload | null } | { error: string } {
+  const raw = sp.get("cursor");
+  if (raw === null) return { cursor: null };
+  const result = decodeCursor(raw);
+  if ("error" in result) return { error: result.error };
+  return { cursor: result.payload };
 }
 
 // =============================================================================
@@ -284,6 +476,7 @@ export async function GET(request: NextRequest) {
 
     const sp = new URL(request.url).searchParams;
 
+    // -- Parse all params before any DB work ----------------------------------
     const windowResult = parseWindowDays(sp);
     if ("error" in windowResult) return badRequest(windowResult.error);
     const windowDays = windowResult.windowDays;
@@ -300,8 +493,31 @@ export async function GET(request: NextRequest) {
     if ("error" in limitResult) return badRequest(limitResult.error);
     const limit = limitResult.limit;
 
+    const ttResult = parseTriggerTypes(sp);
+    if ("error" in ttResult) return badRequest(ttResult.error);
+    const triggerTypesFilter = ttResult.triggerTypes; // null = no filter
+
+    const ktIdResult = parseKeywordTargetId(sp);
+    if ("error" in ktIdResult) return badRequest(ktIdResult.error);
+    const keywordTargetIdFilter = ktIdResult.keywordTargetId; // null = no filter
+
+    const minSevResult = parseMinSeverityRank(sp);
+    if ("error" in minSevResult) return badRequest(minSevResult.error);
+    const minSeverityRank = minSevResult.minSeverityRank; // null = no filter
+
+    const minPvsResult = parseMinPairVolatilityScore(sp);
+    if ("error" in minPvsResult) return badRequest(minPvsResult.error);
+    const minPairVolatilityScore = minPvsResult.minPairVolatilityScore; // null = no filter
+
+    const cursorResult = parseCursor(sp);
+    if ("error" in cursorResult) return badRequest(cursorResult.error);
+    const cursorPayload = cursorResult.cursor; // null = first page
+
+    // If keywordTargetId filter is present, T3 is excluded (T3 is project-scope,
+    // not keyword-scope; its keywordTargetId is null, which cannot match a UUID).
+    // This is enforced in the filter step below — no special branching needed here.
+
     // Single requestTime anchor — all window boundaries derived here.
-    // Alert trigger conditions are functions of snapshot rows only.
     const requestTime = new Date();
     const windowStart = new Date(requestTime.getTime() - windowDays * 24 * 60 * 60 * 1000);
 
@@ -349,15 +565,15 @@ export async function GET(request: NextRequest) {
       if (ms > latestCapturedAtMs) latestCapturedAtMs = ms;
     }
 
-    // ── Collect alerts ────────────────────────────────────────────────────────
-    const alerts: AnyAlert[] = [];
+    // ── Collect all candidate alerts (unfiltered) ─────────────────────────────
+    const allAlerts: AnyAlert[] = [];
 
     // T2 dedup key set: (keywordTargetId, toSnapshotId, threshold)
     const t2DedupSet = new Set<string>();
 
     // B2 accumulators for T3
-    let activeKeywordCount   = 0;
-    let totalVolatilitySum   = 0;
+    let activeKeywordCount = 0;
+    let totalVolatilitySum = 0;
     interface ActiveRecord {
       keywordTargetId: string;
       query:           string;
@@ -366,14 +582,10 @@ export async function GET(request: NextRequest) {
     const activeRecords: ActiveRecord[] = [];
 
     for (const target of targets) {
-      const key  = `${target.query}\0${target.locale}\0${target.device}`;
+      const key   = `${target.query}\0${target.locale}\0${target.device}`;
       const snaps = snapshotMap.get(key) ?? [];
 
-      // Need at least 2 snapshots for any pair-based trigger
-      if (snaps.length < 2) {
-        // Still accumulate for T3 (sampleSize=0, score=0 — but that means not active)
-        continue;
-      }
+      if (snaps.length < 2) continue;
 
       // Compute all consecutive pairs
       interface PairRecord {
@@ -400,8 +612,7 @@ export async function GET(request: NextRequest) {
         });
       }
 
-      // Keyword-level volatility for T3 B2 accumulation
-      // Use computeVolatility across all pairs (pass all snaps)
+      // Accumulate full-keyword volatility for T3
       const fullProfile = computeVolatility(snaps);
       if (fullProfile.sampleSize >= 1) {
         activeKeywordCount++;
@@ -414,8 +625,6 @@ export async function GET(request: NextRequest) {
       }
 
       // ── T1: Regime Transition ─────────────────────────────────────────────
-      // Compare last pair regime vs second-to-last pair regime.
-      // Requires >= 2 pairs (>= 3 snapshots).
       if (pairs.length >= 2) {
         const lastPair = pairs[pairs.length - 1];
         const prevPair = pairs[pairs.length - 2];
@@ -423,7 +632,7 @@ export async function GET(request: NextRequest) {
           const fromRegime = prevPair.regime;
           const toRegime   = lastPair.regime;
           const sevRank    = t1SeverityRank(fromRegime, toRegime);
-          alerts.push({
+          allAlerts.push({
             triggerType:         "T1",
             keywordTargetId:     target.id,
             query:               target.query,
@@ -443,15 +652,13 @@ export async function GET(request: NextRequest) {
       }
 
       // ── T2: Spike Threshold Exceedance ────────────────────────────────────
-      // Emit for each pair where pairVolatilityScore > spikeThreshold.
-      // Dedup within response by (keywordTargetId, toSnapshotId, threshold).
       for (const pair of pairs) {
         if (pair.pairVolatilityScore > spikeThreshold) {
           const dedupKey = `${target.id}\0${pair.toSnapshotId}\0${spikeThreshold}`;
           if (!t2DedupSet.has(dedupKey)) {
             t2DedupSet.add(dedupKey);
             const exceedanceMargin = Math.round((pair.pairVolatilityScore - spikeThreshold) * 100) / 100;
-            alerts.push({
+            allAlerts.push({
               triggerType:         "T2",
               keywordTargetId:     target.id,
               query:               target.query,
@@ -473,29 +680,25 @@ export async function GET(request: NextRequest) {
     }
 
     // ── T3: Risk Concentration Exceedance ─────────────────────────────────────
-    // Compute concentration ratio using B2 formula.
-    // Emitted at most once per request.
-    let volatilityConcentrationRatio: number | null = null;
     if (totalVolatilitySum > 0) {
-      // Sort for top3: volatilityScore DESC, query ASC, keywordTargetId ASC
       activeRecords.sort((a, b) => {
         if (b.volatilityScore !== a.volatilityScore) return b.volatilityScore - a.volatilityScore;
         const qCmp = a.query.localeCompare(b.query);
         if (qCmp !== 0) return qCmp;
         return a.keywordTargetId.localeCompare(b.keywordTargetId);
       });
-      const top3 = activeRecords.slice(0, 3);
+      const top3    = activeRecords.slice(0, 3);
       const top3Sum = top3.reduce((acc, r) => acc + r.volatilityScore, 0);
-      volatilityConcentrationRatio = Math.round((top3Sum / totalVolatilitySum) * 10000) / 10000;
+      const volatilityConcentrationRatio = Math.round((top3Sum / totalVolatilitySum) * 10000) / 10000;
 
       if (volatilityConcentrationRatio > concentrationThreshold) {
         const top3RiskKeywords = top3.map((r) => ({
-          keywordTargetId: r.keywordTargetId,
-          query:           r.query,
-          volatilityScore: r.volatilityScore,
+          keywordTargetId:  r.keywordTargetId,
+          query:            r.query,
+          volatilityScore:  r.volatilityScore,
           volatilityRegime: classifyRegime(r.volatilityScore),
         }));
-        alerts.push({
+        allAlerts.push({
           triggerType:                  "T3",
           projectId,
           volatilityConcentrationRatio,
@@ -509,26 +712,76 @@ export async function GET(request: NextRequest) {
         });
       }
     }
-    // If totalVolatilitySum = 0 → ratio is null → no T3 alert (null guard per spec)
 
     // ── Sort deterministically ────────────────────────────────────────────────
-    alerts.sort(compareAlerts);
+    allAlerts.sort(compareAlerts);
 
-    // ── Apply limit ───────────────────────────────────────────────────────────
-    const page = alerts.slice(0, limit);
+    // ── Apply filters (post-sort; filtering never changes order, only membership) ─
+    // The filtered array preserves relative order of the sorted allAlerts array.
+    const filtered = allAlerts.filter((alert) => {
+      // triggerType filter
+      if (triggerTypesFilter !== null && !triggerTypesFilter.has(alert.triggerType)) {
+        return false;
+      }
+      // keywordTargetId filter — T3 has null _keywordTargetId, so it is
+      // excluded whenever keywordTargetIdFilter is a non-null UUID.
+      if (keywordTargetIdFilter !== null && alert._keywordTargetId !== keywordTargetIdFilter) {
+        return false;
+      }
+      // minSeverityRank filter
+      if (minSeverityRank !== null && alert._severityRank < minSeverityRank) {
+        return false;
+      }
+      // minPairVolatilityScore filter — only applied to T2
+      if (minPairVolatilityScore !== null && alert.triggerType === "T2") {
+        if ((alert as T2Alert).pairVolatilityScore < minPairVolatilityScore) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    // ── Apply cursor (keyset positional cut — in-memory after filter+sort) ────
+    // filtered is already in deterministic sort order.
+    // Find the first item strictly after the cursor position.
+    let startIndex = 0;
+    if (cursorPayload !== null) {
+      // Linear scan to find the first item after cursor.
+      // Correct and deterministic; for typical alert volumes (< 1000) this is fast.
+      let found = false;
+      for (let i = 0; i < filtered.length; i++) {
+        if (isAfterCursor(filtered[i], cursorPayload)) {
+          startIndex = i;
+          found = true;
+          break;
+        }
+      }
+      if (!found) startIndex = filtered.length; // cursor is past the end → empty page
+    }
+
+    // ── Slice page ────────────────────────────────────────────────────────────
+    const page    = filtered.slice(startIndex, startIndex + limit);
+    const hasMore = startIndex + limit < filtered.length;
+
+    // nextCursor encodes the last item on this page (using its sort-assist fields)
+    const nextCursor: string | null = hasMore && page.length > 0
+      ? encodeCursor(page[page.length - 1])
+      : null;
 
     // ── Strip sort-assist fields ──────────────────────────────────────────────
     const emitted = page.map(stripSortFields);
 
     return successResponse({
-      alerts:                   emitted,
-      alertCount:               emitted.length,
-      totalAlerts:              alerts.length,
+      alerts:                emitted,
+      alertCount:            emitted.length,
+      totalAlerts:           filtered.length,
+      nextCursor,
+      hasMore,
       windowDays,
       spikeThreshold,
       concentrationThreshold,
       limit,
-      computedAt:               requestTime.toISOString(),
+      computedAt:            requestTime.toISOString(),
     });
   } catch (err) {
     console.error("GET /api/seo/alerts error:", err);


### PR DESCRIPTION
## Summary

Extends `/api/seo/alerts` with deterministic filtering and keyset pagination (SIL-9.1).

Adds:
- triggerTypes filter (T1, T2, T3)
- keywordTargetId filter (suppresses T3 when present)
- minSeverityRank filter
- minPairVolatilityScore filter (T2 only)
- Deterministic keyset pagination via opaque base64url cursor
- nextCursor + hasMore response fields

## Determinism

Ordering unchanged:
1. severityRank DESC
2. toCapturedAt DESC
3. triggerType ASC
4. keywordTargetId ASC (nulls last)
5. toSnapshotId DESC (nulls last)

Cursor encodes full sort tuple:
{ s, t, tt, k, sn }

`isAfterCursor()` mirrors comparator exactly.
No offset pagination used.

## Validation

Strict validation before DB work:
- triggerTypes tokens validated
- keywordTargetId UUID validated
- minSeverityRank range checked
- minPairVolatilityScore range checked
- cursor base64url + structural validation

## Hammer Coverage

Extended `hammer-sil9.ps1`:
- Pagination correctness (no duplicates, stable nextCursor)
- Filter behavior
- Validation errors
- Determinism checks

Total tests: 308 passing
Build: green

## Architecture

- Compute-on-read only
- No schema changes
- No writes
- No background jobs
- Isolation preserved at DB boundary

Ready for review.