### PR TITLE
feat(seo): add opt-in AI churn cluster alerts (SIL-9 T4)

### DIFF
--- a/scripts/hammer/hammer-sil9.ps1
+++ b/scripts/hammer/hammer-sil9.ps1
@@ -177,7 +177,7 @@ try {
         if ($items.Count -eq 0) {
             Write-Host "  SKIP (no alerts returned)" -ForegroundColor DarkYellow; Hammer-Record SKIP
         } else {
-            $invalid = $items | Where-Object { @("T1","T2","T3") -notcontains $_.triggerType }
+            $invalid = $items | Where-Object { @("T1","T2","T3","T4") -notcontains $_.triggerType }
             if ($invalid.Count -eq 0) {
                 Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
             } else {
@@ -362,6 +362,142 @@ try {
                 }
             }
         }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# =============================================================================
+# SIL-9 T4: AI CHURN CLUSTER TESTS
+# =============================================================================
+
+Hammer-Section "SIL-9 T4 TESTS (AI CHURN CLUSTER — OPT-IN)"
+
+# ── SIL9-T4-A: triggerTypes=T4 without aiChurnMinFlips → 400 ───────────────
+try {
+    Write-Host "Testing: SIL9-T4-A /alerts triggerTypes=T4 without aiChurnMinFlips -> 400" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&triggerTypes=T4" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 400) {
+        Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 400)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-T4-B: with aiChurnMinFlips=2 returns 200 + valid response shape ─────
+try {
+    Write-Host "Testing: SIL9-T4-B /alerts triggerTypes=T4&aiChurnMinFlips=2 returns 200 with valid shape" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&triggerTypes=T4&aiChurnMinFlips=2" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $d    = ($resp.Content | ConvertFrom-Json).data
+        $props = $d | Get-Member -MemberType NoteProperty | Select-Object -ExpandProperty Name
+        $required = @("alerts","alertCount","totalAlerts","nextCursor","hasMore",
+                      "windowDays","limit","computedAt","aiChurnMinFlips","aiChurnMaxGapDays","aiChurnWindowDays")
+        $missing = $required | Where-Object { $props -notcontains $_ }
+        if ($missing.Count -eq 0) {
+            $t4cnt = @($d.alerts | Where-Object { $_.triggerType -eq "T4" }).Count
+            Write-Host ("  PASS (200; required fields present; T4 alerts=" + $t4cnt + ")") -ForegroundColor Green; Hammer-Record PASS
+        } else {
+            Write-Host ("  FAIL (missing fields: " + ($missing -join ", ") + ")") -ForegroundColor Red; Hammer-Record FAIL
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-T4-C: determinism (two identical T4-only calls yield identical results) ──
+try {
+    Write-Host "Testing: SIL9-T4-C /alerts T4-only determinism" -NoNewline
+    $url = "$Base$sil9Base`?windowDays=30&triggerTypes=T4&aiChurnMinFlips=2"
+    $r1  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    $r2  = Invoke-WebRequest -Uri $url -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($r1.StatusCode -eq 200 -and $r2.StatusCode -eq 200) {
+        $d1   = ($r1.Content | ConvertFrom-Json).data
+        $d2   = ($r2.Content | ConvertFrom-Json).data
+        $arr1 = ($d1.alerts | ConvertTo-Json -Depth 10 -Compress)
+        $arr2 = ($d2.alerts | ConvertTo-Json -Depth 10 -Compress)
+        if ($arr1 -eq $arr2 -and $d1.totalAlerts -eq $d2.totalAlerts -and $d1.nextCursor -eq $d2.nextCursor) {
+            Write-Host "  PASS" -ForegroundColor Green; Hammer-Record PASS
+        } else {
+            Write-Host "  FAIL (results differ between two calls)" -ForegroundColor Red; Hammer-Record FAIL
+        }
+    } else { Write-Host ("  FAIL (status=" + $r1.StatusCode + "/" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-T4-D: triggerTypes=T4 returns only T4 alerts (or empty) ────────────
+try {
+    Write-Host "Testing: SIL9-T4-D /alerts triggerTypes=T4 returns only triggerType=T4" -NoNewline
+    $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?windowDays=30&triggerTypes=T4&aiChurnMinFlips=2" `
+        -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($resp.StatusCode -eq 200) {
+        $items  = @(($resp.Content | ConvertFrom-Json).data.alerts)
+        $nonT4  = $items | Where-Object { $_.triggerType -ne "T4" }
+        if ($nonT4.Count -eq 0) {
+            Write-Host ("  PASS (" + $items.Count + " alerts, all T4)") -ForegroundColor Green; Hammer-Record PASS
+        } else {
+            Write-Host ("  FAIL (" + $nonT4.Count + " non-T4 alerts returned)") -ForegroundColor Red; Hammer-Record FAIL
+        }
+    } else { Write-Host ("  FAIL (got " + $resp.StatusCode + ", expected 200)") -ForegroundColor Red; Hammer-Record FAIL }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-T4-E: cursor pagination works with T4 results (no duplicates) ────────
+try {
+    Write-Host "Testing: SIL9-T4-E /alerts T4 cursor pagination produces no duplicates" -NoNewline
+    $url1 = "$Base$sil9Base`?windowDays=30&triggerTypes=T4&aiChurnMinFlips=2&limit=1"
+    $r1   = Invoke-WebRequest -Uri $url1 -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+    if ($r1.StatusCode -ne 200) {
+        Write-Host ("  FAIL (page1 status=" + $r1.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL
+    } else {
+        $d1  = ($r1.Content | ConvertFrom-Json).data
+        $nc1 = $d1.nextCursor
+        $tot = [int]$d1.totalAlerts
+        if ($tot -lt 2 -or $null -eq $nc1) {
+            Write-Host "  SKIP (fewer than 2 T4 alerts in fixture; cannot verify pagination)" -ForegroundColor DarkYellow; Hammer-Record SKIP
+        } else {
+            $url2 = "$Base$sil9Base`?windowDays=30&triggerTypes=T4&aiChurnMinFlips=2&limit=1&cursor=$([System.Uri]::EscapeDataString($nc1))"
+            $r2   = Invoke-WebRequest -Uri $url2 -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+            if ($r2.StatusCode -ne 200) {
+                Write-Host ("  FAIL (page2 status=" + $r2.StatusCode + ")") -ForegroundColor Red; Hammer-Record FAIL
+            } else {
+                $items2 = @(($r2.Content | ConvertFrom-Json).data.alerts)
+                if ($items2.Count -eq 0) {
+                    Write-Host "  FAIL (page2 empty despite totalAlerts >= 2)" -ForegroundColor Red; Hammer-Record FAIL
+                } else {
+                    $p1json = ($d1.alerts[0] | ConvertTo-Json -Depth 10 -Compress)
+                    $p2json = ($items2[0]    | ConvertTo-Json -Depth 10 -Compress)
+                    if ($p1json -ne $p2json) {
+                        Write-Host "  PASS (no duplicate across pages)" -ForegroundColor Green; Hammer-Record PASS
+                    } else {
+                        Write-Host "  FAIL (page2 item[0] duplicates page1 item[0])" -ForegroundColor Red; Hammer-Record FAIL
+                    }
+                }
+            }
+        }
+    }
+} catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
+
+# ── SIL9-T4-V: out-of-range param values → 400 ───────────────────────────
+try {
+    Write-Host "Testing: SIL9-T4-V /alerts out-of-range T4 params -> 400" -NoNewline
+    $cases = @(
+        # aiChurnMinFlips out of range
+        "windowDays=30&triggerTypes=T4&aiChurnMinFlips=1",       # below min (2)
+        "windowDays=30&triggerTypes=T4&aiChurnMinFlips=21",      # above max (20)
+        # aiChurnMaxGapDays out of range
+        "windowDays=30&triggerTypes=T4&aiChurnMinFlips=2&aiChurnMaxGapDays=0",   # below min (1)
+        "windowDays=30&triggerTypes=T4&aiChurnMinFlips=2&aiChurnMaxGapDays=31",  # above max (30)
+        # aiChurnWindowDays out of range
+        "windowDays=30&triggerTypes=T4&aiChurnMinFlips=2&aiChurnWindowDays=0",   # below min (1)
+        "windowDays=30&triggerTypes=T4&aiChurnMinFlips=2&aiChurnWindowDays=31"   # above max (30)
+    )
+    $failures = @()
+    foreach ($qs in $cases) {
+        $resp = Invoke-WebRequest -Uri "$Base$sil9Base`?$qs" `
+            -Method GET -Headers $Headers -SkipHttpErrorCheck -TimeoutSec 30 -UseBasicParsing
+        if ($resp.StatusCode -ne 400) {
+            $failures += "$qs -> " + $resp.StatusCode
+        }
+    }
+    if ($failures.Count -eq 0) {
+        Write-Host ("  PASS (all " + $cases.Count + " out-of-range cases returned 400)") -ForegroundColor Green; Hammer-Record PASS
+    } else {
+        Write-Host ("  FAIL (" + $failures.Count + " cases did not return 400: " + ($failures -join "; ") + ")") -ForegroundColor Red; Hammer-Record FAIL
     }
 } catch { Write-Host ("  FAIL (exception: " + $_.Exception.Message + ")") -ForegroundColor Red; Hammer-Record FAIL }
 
@@ -768,7 +904,7 @@ try {
             # If the formula errors it would throw and give 500. The 200 response is the first guard.
             #
             # Additional structural check: all items have triggerType in {T1,T2,T3}.
-            $invalid = $items | Where-Object { @("T1","T2","T3") -notcontains $_.triggerType }
+            $invalid = $items | Where-Object { @("T1","T2","T3","T4") -notcontains $_.triggerType }
             if ($invalid.Count -eq 0) {
                 Write-Host ("  PASS (" + $items.Count + " alerts returned with valid structure; severity computed without error)") -ForegroundColor Green; Hammer-Record PASS
             } else {

--- a/src/app/api/seo/alerts/route.ts
+++ b/src/app/api/seo/alerts/route.ts
@@ -83,8 +83,17 @@ const T3_DELTA_ONLY_MIN_DELTA = 0.05;
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const VALID_TRIGGER_TYPES = new Set(["T1", "T2", "T3"] as const);
-type TriggerTypeToken = "T1" | "T2" | "T3";
+const VALID_TRIGGER_TYPES = new Set(["T1", "T2", "T3", "T4"] as const);
+type TriggerTypeToken = "T1" | "T2" | "T3" | "T4";
+
+// T4 — AI Churn Cluster constants
+const AI_CHURN_MIN_FLIPS_MIN     = 2;
+const AI_CHURN_MIN_FLIPS_MAX     = 20;
+const AI_CHURN_MAX_GAP_DAYS_DEFAULT = 7;
+const AI_CHURN_MAX_GAP_DAYS_MIN  = 1;
+const AI_CHURN_MAX_GAP_DAYS_MAX  = 30;
+// aiChurnWindowDays defaults to windowDays; same min/max as windowDays
+const MS_PER_DAY = 86_400_000;
 
 // =============================================================================
 // Suppression param types
@@ -167,6 +176,24 @@ function computeT3SeverityRank(
   return clamp(Math.round(70 + exceed * 200), 0, 100);
 }
 
+/**
+ * T4 severity — AI churn cluster density.
+ *
+ * excessFlips = flipCount - aiChurnMinFlips  (>= 0)
+ * tightness   = 1 - (clusterDurationMs / (aiChurnMaxGapDays * MS_PER_DAY)), clamped [0, 1]
+ * result      = clamp(round(65 + excessFlips * 5 + tightness * 20), 0, 100)
+ */
+function computeT4SeverityRank(
+  flipCount:          number,
+  aiChurnMinFlips:    number,
+  clusterDurationMs:  number,
+  aiChurnMaxGapDays:  number,
+): number {
+  const excessFlips = flipCount - aiChurnMinFlips;
+  const tightness   = clamp(1 - clusterDurationMs / (aiChurnMaxGapDays * MS_PER_DAY), 0, 1);
+  return clamp(Math.round(65 + excessFlips * 5 + tightness * 20), 0, 100);
+}
+
 // =============================================================================
 // Alert union types
 // =============================================================================
@@ -223,12 +250,31 @@ interface T3Alert {
   _keywordTargetId:    null;
 }
 
-type AnyAlert = T1Alert | T2Alert | T3Alert;
+interface T4Alert {
+  triggerType:           "T4";
+  keywordTargetId:       string;
+  query:                 string;
+  flipCount:             number;
+  clusterFirstFlipAt:    string; // ISO
+  clusterLastFlipAt:     string; // ISO
+  clusterDurationDays:   number; // rounded 2 decimals
+  aiChurnMinFlips:       number;
+  aiChurnMaxGapDays:     number;
+  aiChurnWindowDays:     number;
+  // sort-assist
+  _severityRank:         number;
+  _toCapturedAtMs:       number;
+  _toSnapshotId:         string;
+  _keywordTargetId:      string;
+}
+
+type AnyAlert = T1Alert | T2Alert | T3Alert | T4Alert;
 
 type T1Emitted    = Omit<T1Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
 type T2Emitted    = Omit<T2Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
 type T3Emitted    = Omit<T3Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
-type AlertEmitted = T1Emitted | T2Emitted | T3Emitted;
+type T4Emitted    = Omit<T4Alert, "_severityRank" | "_toCapturedAtMs" | "_toSnapshotId" | "_keywordTargetId">;
+type AlertEmitted = T1Emitted | T2Emitted | T3Emitted | T4Emitted;
 
 // =============================================================================
 // Cursor
@@ -533,7 +579,7 @@ function parseTriggerTypes(
   const set = new Set<TriggerTypeToken>();
   for (const token of tokens) {
     if (!VALID_TRIGGER_TYPES.has(token as TriggerTypeToken)) {
-      return { error: `triggerTypes contains invalid token: "${token}". Valid values: T1, T2, T3` };
+      return { error: `triggerTypes contains invalid token: "${token}". Valid values: T1, T2, T3, T4` };
     }
     set.add(token as TriggerTypeToken);
   }
@@ -631,6 +677,173 @@ function parseT3Mode(
     return { error: `t3Mode must be "all" or "deltaOnly"` };
   }
   return { t3Mode: raw };
+}
+
+// =============================================================================
+// T4 param parsers
+// =============================================================================
+
+interface T4Params {
+  active:            boolean; // false when T4 not in triggerTypes
+  aiChurnMinFlips:   number;
+  aiChurnMaxGapDays: number;
+  aiChurnWindowDays: number; // resolved (defaults to windowDays)
+}
+
+function parseT4Params(
+  sp: URLSearchParams,
+  triggerTypesFilter: Set<TriggerTypeToken> | null,
+  windowDays: number,
+): { t4: T4Params } | { error: string } {
+  const t4Active = triggerTypesFilter === null
+    ? false // T4 is opt-in; only active when explicitly requested
+    : triggerTypesFilter.has("T4");
+
+  if (!t4Active) {
+    // T4 not requested — parse nothing, return inactive sentinel
+    return {
+      t4: {
+        active:            false,
+        aiChurnMinFlips:   0,
+        aiChurnMaxGapDays: AI_CHURN_MAX_GAP_DAYS_DEFAULT,
+        aiChurnWindowDays: windowDays,
+      },
+    };
+  }
+
+  // T4 is active — aiChurnMinFlips is required
+  const rawMinFlips = sp.get("aiChurnMinFlips");
+  if (rawMinFlips === null) {
+    return { error: "aiChurnMinFlips is required when triggerTypes includes T4" };
+  }
+  if (!/^\d+$/.test(rawMinFlips)) {
+    return { error: "aiChurnMinFlips must be an integer" };
+  }
+  const minFlips = parseInt(rawMinFlips, 10);
+  if (minFlips < AI_CHURN_MIN_FLIPS_MIN) {
+    return { error: `aiChurnMinFlips must be >= ${AI_CHURN_MIN_FLIPS_MIN}` };
+  }
+  if (minFlips > AI_CHURN_MIN_FLIPS_MAX) {
+    return { error: `aiChurnMinFlips must be <= ${AI_CHURN_MIN_FLIPS_MAX}` };
+  }
+
+  const rawMaxGap = sp.get("aiChurnMaxGapDays");
+  let maxGapDays = AI_CHURN_MAX_GAP_DAYS_DEFAULT;
+  if (rawMaxGap !== null) {
+    if (!/^\d+$/.test(rawMaxGap)) return { error: "aiChurnMaxGapDays must be an integer" };
+    maxGapDays = parseInt(rawMaxGap, 10);
+    if (maxGapDays < AI_CHURN_MAX_GAP_DAYS_MIN) return { error: `aiChurnMaxGapDays must be >= ${AI_CHURN_MAX_GAP_DAYS_MIN}` };
+    if (maxGapDays > AI_CHURN_MAX_GAP_DAYS_MAX) return { error: `aiChurnMaxGapDays must be <= ${AI_CHURN_MAX_GAP_DAYS_MAX}` };
+  }
+
+  const rawChurnWin = sp.get("aiChurnWindowDays");
+  let churnWindowDays = windowDays; // default = outer windowDays
+  if (rawChurnWin !== null) {
+    if (!/^\d+$/.test(rawChurnWin)) return { error: "aiChurnWindowDays must be an integer" };
+    churnWindowDays = parseInt(rawChurnWin, 10);
+    if (churnWindowDays < WINDOW_DAYS_MIN) return { error: `aiChurnWindowDays must be >= ${WINDOW_DAYS_MIN}` };
+    if (churnWindowDays > WINDOW_DAYS_MAX) return { error: `aiChurnWindowDays must be <= ${WINDOW_DAYS_MAX}` };
+  }
+
+  return {
+    t4: {
+      active:            true,
+      aiChurnMinFlips:   minFlips,
+      aiChurnMaxGapDays: maxGapDays,
+      aiChurnWindowDays: churnWindowDays,
+    },
+  };
+}
+
+// =============================================================================
+// T4 cluster detection — pure function, no DB calls.
+//
+// Iterates snaps (already sorted capturedAt ASC, id ASC) within aiChurnStart.
+// Collects flip events, then finds the tightest qualifying cluster using a
+// sliding window of aiChurnMinFlips flips.
+//
+// Cluster selection: among all qualifying windows (length >= minFlips, span <=
+// maxGapMs), prefer the sequence ending latest; tie-break: shortest duration.
+// Returns null when no qualifying cluster exists.
+// =============================================================================
+
+interface T4ClusterResult {
+  flipCount:          number;
+  clusterFirstFlipMs: number;
+  clusterLastFlipMs:  number;
+  clusterDurationMs:  number;
+  lastFlipToSnapshotId: string;
+}
+
+function detectT4Cluster(
+  snaps:          Array<{ id: string; capturedAt: Date; aiOverviewStatus: string | null }>,
+  aiChurnStartMs: number,
+  minFlips:       number,
+  maxGapMs:       number,
+): T4ClusterResult | null {
+  // Collect flip events within churn window (pairs where toCapturedAt >= aiChurnStartMs)
+  interface FlipEvent {
+    toCapturedAtMs: number;
+    toSnapshotId:   string;
+  }
+  const flips: FlipEvent[] = [];
+
+  for (let i = 0; i < snaps.length - 1; i++) {
+    const A = snaps[i];
+    const B = snaps[i + 1];
+    const toMs = B.capturedAt.getTime();
+    if (toMs < aiChurnStartMs) continue; // pair outside churn window
+    if (A.aiOverviewStatus !== B.aiOverviewStatus) {
+      flips.push({ toCapturedAtMs: toMs, toSnapshotId: B.id });
+    }
+  }
+
+  if (flips.length < minFlips) return null;
+
+  // Sliding window: find all qualifying sub-sequences of length >= minFlips
+  // within maxGapMs. For determinism, choose:
+  //   1. Latest clusterLastFlipMs
+  //   2. Tie: shortest duration
+  // We check every window of exactly minFlips consecutive flips, then
+  // expand rightward to include additional flips still within maxGapMs.
+
+  let bestResult: T4ClusterResult | null = null;
+
+  for (let i = 0; i <= flips.length - minFlips; i++) {
+    const windowStart = flips[i].toCapturedAtMs;
+    // Find rightmost flip within maxGapMs from windowStart
+    let j = i + minFlips - 1; // minimum right index
+    // Expand right while next flip is still within maxGapMs
+    while (j + 1 < flips.length && flips[j + 1].toCapturedAtMs - windowStart <= maxGapMs) {
+      j++;
+    }
+    const span = flips[j].toCapturedAtMs - windowStart;
+    if (span > maxGapMs) continue; // minimum window itself exceeds gap (shouldn't happen but guard)
+
+    const candidate: T4ClusterResult = {
+      flipCount:            j - i + 1,
+      clusterFirstFlipMs:   windowStart,
+      clusterLastFlipMs:    flips[j].toCapturedAtMs,
+      clusterDurationMs:    span,
+      lastFlipToSnapshotId: flips[j].toSnapshotId,
+    };
+
+    if (bestResult === null) {
+      bestResult = candidate;
+    } else {
+      // Prefer later last flip
+      if (candidate.clusterLastFlipMs > bestResult.clusterLastFlipMs) {
+        bestResult = candidate;
+      } else if (candidate.clusterLastFlipMs === bestResult.clusterLastFlipMs) {
+        // Tie: prefer shorter duration
+        if (candidate.clusterDurationMs < bestResult.clusterDurationMs) {
+          bestResult = candidate;
+        }
+      }
+    }
+  }
+
+  return bestResult;
 }
 
 // =============================================================================
@@ -747,6 +960,11 @@ export async function GET(request: NextRequest) {
     const t3Mode = t3Result.t3Mode;
 
     const suppressionOpts: SuppressionOpts = { suppressionMode, t1Mode, t2Mode, t3Mode };
+
+    // T4 params — parsed after triggerTypes + windowDays are resolved
+    const t4Result = parseT4Params(sp, triggerTypesFilter, windowDays);
+    if ("error" in t4Result) return badRequest(t4Result.error);
+    const t4Params = t4Result.t4;
 
     // Single requestTime anchor — all window boundaries derived here.
     const requestTime  = new Date();
@@ -973,6 +1191,51 @@ export async function GET(request: NextRequest) {
       }
     }
 
+    // T4 — AI Churn Cluster (opt-in, per-keyword)
+    if (t4Params.active) {
+      const aiChurnStartMs = requestTime.getTime() - t4Params.aiChurnWindowDays * MS_PER_DAY;
+      const maxGapMs       = t4Params.aiChurnMaxGapDays * MS_PER_DAY;
+
+      for (const target of targets) {
+        const key   = `${target.query}\0${target.locale}\0${target.device}`;
+        const snaps = snapshotMap.get(key) ?? [];
+        if (snaps.length < 2) continue;
+
+        const cluster = detectT4Cluster(
+          snaps,
+          aiChurnStartMs,
+          t4Params.aiChurnMinFlips,
+          maxGapMs,
+        );
+        if (cluster === null) continue;
+
+        const clusterDurationDays =
+          Math.round((cluster.clusterDurationMs / MS_PER_DAY) * 100) / 100;
+
+        allAlerts.push({
+          triggerType:         "T4",
+          keywordTargetId:     target.id,
+          query:               target.query,
+          flipCount:           cluster.flipCount,
+          clusterFirstFlipAt:  new Date(cluster.clusterFirstFlipMs).toISOString(),
+          clusterLastFlipAt:   new Date(cluster.clusterLastFlipMs).toISOString(),
+          clusterDurationDays,
+          aiChurnMinFlips:     t4Params.aiChurnMinFlips,
+          aiChurnMaxGapDays:   t4Params.aiChurnMaxGapDays,
+          aiChurnWindowDays:   t4Params.aiChurnWindowDays,
+          _severityRank:       computeT4SeverityRank(
+                                 cluster.flipCount,
+                                 t4Params.aiChurnMinFlips,
+                                 cluster.clusterDurationMs,
+                                 t4Params.aiChurnMaxGapDays,
+                               ),
+          _toCapturedAtMs:     cluster.clusterLastFlipMs,
+          _toSnapshotId:       cluster.lastFlipToSnapshotId,
+          _keywordTargetId:    target.id,
+        });
+      }
+    }
+
     // ── Sort deterministically ────────────────────────────────────────────────
     allAlerts.sort(compareAlerts);
 
@@ -1038,6 +1301,11 @@ export async function GET(request: NextRequest) {
       t1Mode,
       t2Mode,
       t3Mode,
+      ...(t4Params.active ? {
+        aiChurnMinFlips:   t4Params.aiChurnMinFlips,
+        aiChurnMaxGapDays: t4Params.aiChurnMaxGapDays,
+        aiChurnWindowDays: t4Params.aiChurnWindowDays,
+      } : {}),
       limit,
       computedAt:            requestTime.toISOString(),
     });


### PR DESCRIPTION
## Summary

Implements SIL-9 T4 — AI Churn Cluster Detection — as an opt-in alert trigger within `/api/seo/alerts`.

T4 is only activated when:
- `triggerTypes` includes `T4`
- `aiChurnMinFlips` is provided

No behavior changes to T1–T3.

## Parameters

- aiChurnMinFlips (2–20, required for activation)
- aiChurnMaxGapDays (1–30, default 7)
- aiChurnWindowDays (1–30, default = windowDays)

Strict validation enforced before DB work.

## Detection Logic

Per keywordTarget:
- Detect AI overview status flips across consecutive snapshots
- Identify the most recent qualifying cluster where:
  - flipCount >= aiChurnMinFlips
  - cluster duration <= aiChurnMaxGapDays
- Deterministic tie-breakers applied if multiple clusters exist

One T4 alert emitted per keyword per request.

## Severity

Deterministic integer severityRank:
- Based on excess flips and cluster tightness
- Clamped to [0, 100]

## Determinism & Architecture

- Single requestTime anchor
- No writes
- No schema changes
- Compute-on-read only
- Isolation enforced at DB boundary
- Cursor + pagination semantics unchanged

## Hammer Coverage

Extended hammer-sil9.ps1:
- Activation gate validation
- Determinism checks
- Filtering correctness
- Pagination under T4
- Parameter range validation

327 / 327 tests passing.
Build green.

Ready for review.