### PR TITLE
chore(audit): strict write schemas + remove validation EventLogs

### DIFF
--- a/src/app/api/entities/[id]/request-publish/route.ts
+++ b/src/app/api/entities/[id]/request-publish/route.ts
@@ -4,7 +4,7 @@
  * Phase 1 Publish Lifecycle - Chunk 2: Publish review flow
  * - Validates entity before allowing publish request
  * - Enforces state transitions (draft -> publish_requested)
- * - Logs validation failures and publish requests
+ * - EventLog only on actual state change (per INV-3.2)
  *
  * Multi-project hardened:
  * - Resolves projectId from request
@@ -21,7 +21,6 @@ import {
   serverError,
 } from "@/lib/api-response";
 import { validateEntityForPublish } from "@/lib/entity-validation";
-import type { Prisma } from "@prisma/client";
 import { resolveProjectId } from "@/lib/project";
 
 const UUID_RE =
@@ -74,32 +73,7 @@ export async function POST(
     const validation = await validateEntityForPublish({ entity, projectId });
 
     if (validation.status === "fail") {
-      // Log validation failure event (no state change)
-      const errorsJson: Prisma.InputJsonArray = validation.errors.map((e) => ({
-        code: e.code,
-        category: e.category,
-        level: e.level,
-        message: e.message,
-      }));
-
-      const details: Prisma.InputJsonObject = {
-        status: validation.status,
-        categories: validation.categories,
-        errors: errorsJson,
-      };
-
-      await prisma.eventLog.create({
-        data: {
-          eventType: "ENTITY_VALIDATION_FAILED",
-          entityType: entity.entityType,
-          entityId: entity.id,
-          actor: "human",
-          projectId,
-          details,
-        },
-      });
-
-      // Return 409 with validation errors
+      // Return 409 with validation errors (no EventLog - no state change per INV-3.2)
       return errorResponse(
         "VALIDATION_FAILED",
         "Cannot request publish: validation failed",

--- a/src/app/api/entities/[id]/validate/route.ts
+++ b/src/app/api/entities/[id]/validate/route.ts
@@ -4,12 +4,11 @@
  * Phase 1 Publish Lifecycle - Chunk 1: Entity validation spine
  * - Deterministic validation only (no LLM, no network calls)
  * - Returns validation status without changing publish state
- * - Logs ENTITY_VALIDATION_FAILED event on failure
+ * - No EventLog writes (read-only operation per INV-3.2)
  *
  * Multi-project hardened:
  * - Resolves projectId from request
  * - Verifies entity belongs to project
- * - Uses resolved projectId for events
  * - No unsafe Prisma JSON casting
  */
 import { NextRequest } from "next/server";
@@ -21,7 +20,6 @@ import {
   serverError,
 } from "@/lib/api-response";
 import { validateEntityForPublish } from "@/lib/entity-validation";
-import type { Prisma } from "@prisma/client";
 import { resolveProjectId } from "@/lib/project";
 
 const UUID_RE =
@@ -64,33 +62,7 @@ export async function POST(
     // Run deterministic validation (projectId-scoped per §1.2)
     const validation = await validateEntityForPublish({ entity, projectId });
 
-    // Log validation failure event if needed (no state change)
-    if (validation.status === "fail") {
-      const errorsJson: Prisma.InputJsonArray = validation.errors.map((e) => ({
-        code: e.code,
-        category: e.category,
-        level: e.level,
-        message: e.message,
-      }));
-
-      const details: Prisma.InputJsonObject = {
-        status: validation.status,
-        categories: validation.categories,
-        errors: errorsJson,
-      };
-
-      await prisma.eventLog.create({
-        data: {
-          eventType: "ENTITY_VALIDATION_FAILED",
-          entityType: entity.entityType,
-          entityId: entity.id,
-          actor: "human",
-          projectId,
-          details,
-        },
-      });
-    }
-
+    // Return validation results (no EventLog - read-only operation per INV-3.2)
     return successResponse({
       status: validation.status,
       categories: validation.categories,

--- a/src/lib/schemas/entity.ts
+++ b/src/lib/schemas/entity.ts
@@ -1,12 +1,14 @@
 import { z } from "zod";
 
-export const CreateEntitySchema = z.object({
-  entityType: z.enum(["guide", "concept", "project", "news"]),
-  title: z.string().min(1),
-  summary: z.string().optional(),
-  difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
-  slug: z.string().optional(),
-  repoUrl: z.string().url().optional(),
-  conceptKind: z.enum(["standard", "model", "comparison"]).optional(),
-  llmAssisted: z.boolean().optional(),
-});
+export const CreateEntitySchema = z
+  .object({
+    entityType: z.enum(["guide", "concept", "project", "news"]),
+    title: z.string().min(1),
+    summary: z.string().optional(),
+    difficulty: z.enum(["beginner", "intermediate", "advanced"]).optional(),
+    slug: z.string().optional(),
+    repoUrl: z.string().url().optional(),
+    conceptKind: z.enum(["standard", "model", "comparison"]).optional(),
+    llmAssisted: z.boolean().optional(),
+  })
+  .strict();

--- a/src/lib/schemas/quotable-block.ts
+++ b/src/lib/schemas/quotable-block.ts
@@ -22,11 +22,13 @@ const isoDateString = z.string().refine(
   "Must be a valid ISO date string"
 );
 
-export const CreateQuotableBlockSchema = z.object({
-  entityId: z.string().regex(UUID_RE, "entityId must be a valid UUID"),
-  text: z.string().min(1),
-  claimType: z.nativeEnum(ClaimType),
-  sourceCitation: z.string().optional(),
-  topicTag: z.string().optional(),
-  verifiedUntil: isoDateString.optional(),
-});
+export const CreateQuotableBlockSchema = z
+  .object({
+    entityId: z.string().regex(UUID_RE, "entityId must be a valid UUID"),
+    text: z.string().min(1),
+    claimType: z.nativeEnum(ClaimType),
+    sourceCitation: z.string().optional(),
+    topicTag: z.string().optional(),
+    verifiedUntil: isoDateString.optional(),
+  })
+  .strict();

--- a/src/lib/schemas/relationship.ts
+++ b/src/lib/schemas/relationship.ts
@@ -4,8 +4,10 @@ import { RelationType } from "@prisma/client";
 const UUID_RE =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-export const CreateRelationshipSchema = z.object({
-  fromEntityId: z.string().regex(UUID_RE, "fromEntityId must be a valid UUID"),
-  toEntityId: z.string().regex(UUID_RE, "toEntityId must be a valid UUID"),
-  relationType: z.nativeEnum(RelationType),
-});
+export const CreateRelationshipSchema = z
+  .object({
+    fromEntityId: z.string().regex(UUID_RE, "fromEntityId must be a valid UUID"),
+    toEntityId: z.string().regex(UUID_RE, "toEntityId must be a valid UUID"),
+    relationType: z.nativeEnum(RelationType),
+  })
+  .strict();

--- a/src/lib/schemas/search-performance.ts
+++ b/src/lib/schemas/search-performance.ts
@@ -36,13 +36,16 @@ const SearchPerformanceRowSchema = z
       .regex(UUID_RE, "entityId must be a valid UUID")
       .nullish(),
   })
+  .strict()
   .refine(
     (row) => row.clicks <= row.impressions,
     "clicks cannot exceed impressions"
   );
 
-export const IngestSearchPerformanceSchema = z.object({
-  rows: z.array(SearchPerformanceRowSchema).min(1),
-});
+export const IngestSearchPerformanceSchema = z
+  .object({
+    rows: z.array(SearchPerformanceRowSchema).min(1),
+  })
+  .strict();
 
 export type SearchPerformanceRow = z.infer<typeof SearchPerformanceRowSchema>;

--- a/src/lib/schemas/source-item.ts
+++ b/src/lib/schemas/source-item.ts
@@ -1,22 +1,24 @@
 import { z } from "zod";
 
-export const CaptureSourceItemSchema = z.object({
-  sourceType: z.enum(["rss", "webpage", "comment", "reply", "video", "other"]),
-  url: z.string().url(),
-  operatorIntent: z.string().min(1),
-  platform: z
-    .enum([
-      "website",
-      "x",
-      "youtube",
-      "github",
-      "reddit",
-      "hackernews",
-      "substack",
-      "linkedin",
-      "discord",
-      "other",
-    ])
-    .optional(),
-  notes: z.string().optional(),
-});
+export const CaptureSourceItemSchema = z
+  .object({
+    sourceType: z.enum(["rss", "webpage", "comment", "reply", "video", "other"]),
+    url: z.string().url(),
+    operatorIntent: z.string().min(1),
+    platform: z
+      .enum([
+        "website",
+        "x",
+        "youtube",
+        "github",
+        "reddit",
+        "hackernews",
+        "substack",
+        "linkedin",
+        "discord",
+        "other",
+      ])
+      .optional(),
+    notes: z.string().optional(),
+  })
+  .strict();


### PR DESCRIPTION
Audit-driven patch:

- Enforce Zod `.strict()` on write schemas to prevent unknown fields (CreateEntity, CreateRelationship, CaptureSourceItem, CreateQuotableBlock, IngestSearchPerformance + nested row schema).
- Remove standalone EventLog writes from validation-only paths to comply with invariant: no EventLog without mutation.

Changes are patch-only:
- No schema changes
- No endpoint refactors
- Hammer discipline preserved

Files modified:
- src/lib/schemas/entity.ts
- src/lib/schemas/relationship.ts
- src/lib/schemas/source-item.ts
- src/lib/schemas/quotable-block.ts
- src/lib/schemas/search-performance.ts
- src/app/api/entities/[id]/validate/route.ts
- src/app/api/entities/[id]/request-publish/route.ts

Commit message:
`chore(audit): enforce strict write schemas and remove validation-only EventLog`